### PR TITLE
Allow {... "error": null ...} in JSON responses.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -829,14 +829,14 @@ apr_byte_t oidc_util_get_request_parameter(request_rec *r, char *name,
 static apr_byte_t oidc_util_json_string_print(request_rec *r, json_t *result,
 		const char *key, const char *log) {
 	json_t *value = json_object_get(result, key);
-	if (value != NULL) {
-		char *s_value = json_dumps(value, 0);
-		oidc_error(r, "%s: response contained an \"%s\" entry with value: \"%s\"",
-				log, key, s_value);
-		free(s_value);
-		return TRUE;
-	}
-	return FALSE;
+	if (value == NULL || json_is_null(value))
+		return FALSE;
+
+	char *s_value = json_dumps(value, 0);
+	oidc_error(r, "%s: response contained an \"%s\" entry with value: \"%s\"",
+			log, key, s_value);
+	free(s_value);
+	return TRUE;
 }
 
 /*


### PR DESCRIPTION
This fixes compatibility issues with MITREid-Connect.