### PR TITLE
Fixing build with OpenSSL <1.0:

### DIFF
--- a/src/jose/apr_jwt.c
+++ b/src/jose/apr_jwt.c
@@ -360,9 +360,11 @@ const char *apr_jwt_signature_to_jwk_type(apr_pool_t *pool, apr_jwt_t *jwt) {
 	if (apr_jws_signature_is_rsa(pool, jwt)) {
 		return "RSA";
 	}
+#if (OPENSSL_VERSION_NUMBER >= 0x01000000)
 	if (apr_jws_signature_is_ec(pool, jwt)) {
 		return "EC";
 	}
+#endif
 	if (apr_jws_signature_is_hmac(pool, jwt)) {
 		return "oct";
 	}


### PR DESCRIPTION
 Only calling apr_jws_signature_is_ec if it's compiled in.