### PR TITLE
Correctly check at_hash also if padding is present

### DIFF
--- a/src/proto.c
+++ b/src/proto.c
@@ -1067,10 +1067,17 @@ static apr_byte_t oidc_proto_validate_hash(request_rec *r, const char *alg,
 
 	/* compare the calculated hash against the provided hash */
 	if ((apr_strnatcmp(encoded, hash) != 0)) {
-		oidc_error(r,
+		if (oidc_base64url_encode(r, &encoded, calc, apr_jws_hash_length(alg) / 2,
+				0) <= 0) {
+			oidc_error(r, "oidc_base64url_encode returned an error");
+			return FALSE;
+		}
+		if ((apr_strnatcmp(encoded, hash) != 0)) {
+			oidc_error(r,
 				"provided \"%s\" hash value (%s) does not match the calculated value (%s)",
 				type, hash, encoded);
-		return FALSE;
+			return FALSE;
+		}
 	}
 
 	oidc_debug(r,

--- a/src/util.c
+++ b/src/util.c
@@ -85,16 +85,14 @@ int oidc_base64url_encode(request_rec *r, char **dst, const char *src,
 			enc[i] = '-';
 		if (enc[i] == '/')
 			enc[i] = '_';
-		if (enc[i] == '=')
-			enc[i] = ',';
 		i++;
 	}
 	if (remove_padding) {
 		/* remove /0 and padding */
 		enc_len--;
-		if (enc[enc_len - 1] == ',')
+		if (enc[enc_len - 1] == '=')
 			enc_len--;
-		if (enc[enc_len - 1] == ',')
+		if (enc[enc_len - 1] == '=')
 			enc_len--;
 		enc[enc_len] = '\0';
 	}


### PR DESCRIPTION
According to rfc4648 (https://tools.ietf.org/html/rfc4648#section-5), padding in base64url encoding is optional. I added a check also also with pad in case the first on fails.