### PR TITLE
Patches to build on El.5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,11 @@ reporting bugs, providing fixes, suggesting useful features or other:
 	Stefano Vercelli <https://github.com/steverc>
 	David Bernick <https://github.com/davidbernick>
 	Joseph Bester <https://github.com/bester>
+
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit. (http://www.OpenSSL.org/)
+See src/jose/aes_wrap.c for copyright and licensing details.
+
+Portions of this product are 
+Copyright (c) 2000-2015 The Apache Software Foundation.
+See src/jose/apr_jwe.c for copyright and licensing details.

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,6 @@
 
 JWT_SRC = \
+	src/jose/aes_wrap.c \
 	src/jose/apr_jwt.c \
 	src/jose/apr_jwk.c \
 	src/jose/apr_jws.c \

--- a/src/cache/cache.h
+++ b/src/cache/cache.h
@@ -87,7 +87,9 @@ apr_byte_t oidc_cache_mutex_unlock(request_rec *r, oidc_cache_mutex_t *m);
 apr_byte_t oidc_cache_mutex_destroy(server_rec *s, oidc_cache_mutex_t *m);
 
 extern oidc_cache_t oidc_cache_file;
+#if USE_MEMCACHE
 extern oidc_cache_t oidc_cache_memcache;
+#endif
 extern oidc_cache_t oidc_cache_shm;
 
 #ifdef USE_LIBHIREDIS

--- a/src/cache/memcache.c
+++ b/src/cache/memcache.c
@@ -50,16 +50,19 @@
  * @Author: Hans Zandbelt - hzandbelt@pingidentity.com
  */
 
+#include "apu_version.h"
 #include "apr_general.h"
 #include "apr_strings.h"
 #include "apr_hash.h"
-#include "apr_memcache.h"
 
 #include <httpd.h>
 #include <http_config.h>
 #include <http_log.h>
 
 #include "../mod_auth_openidc.h"
+
+#if USE_MEMCACHE
+#include "apr_memcache.h"
 
 // TODO: proper memcache error reporting (server unreachable etc.)
 
@@ -274,3 +277,4 @@ oidc_cache_t oidc_cache_memcache = {
 		oidc_cache_memcache_set,
 		NULL
 };
+#endif /* USE_MEMCACHE */

--- a/src/jose/aes_wrap.c
+++ b/src/jose/aes_wrap.c
@@ -1,0 +1,105 @@
+/* crypto/aes/aes_wrap.c */
+/* Written by Dr Stephen N Henson (steve@openssl.org) for the OpenSSL
+ * project.
+ */
+/* ====================================================================
+ * Copyright (c) 2008 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer. 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.OpenSSL.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    licensing@OpenSSL.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.OpenSSL.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ */
+
+#include <string.h>
+#include <openssl/opensslv.h>
+#include <openssl/aes.h>
+#include <openssl/crypto.h>
+
+#if OPENSSL_VERSION < 0x0090809fL
+static const unsigned char default_iv[] = {
+  0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
+};
+
+int AES_unwrap_key(AES_KEY *key, const unsigned char *iv,
+		unsigned char *out,
+		const unsigned char *in, unsigned int inlen)
+	{
+	unsigned char *A, B[16], *R;
+	unsigned int i, j, t;
+	inlen -= 8;
+	if (inlen & 0x7)
+		return -1;
+	if (inlen < 8)
+		return -1;
+	A = B;
+	t =  6 * (inlen >> 3);
+	memcpy(A, in, 8);
+	memcpy(out, in + 8, inlen);
+	for (j = 0; j < 6; j++)
+		{
+		R = out + inlen - 8;
+		for (i = 0; i < inlen; i += 8, t--, R -= 8)
+			{
+			A[7] ^= (unsigned char)(t & 0xff);
+			if (t > 0xff)
+				{
+				A[6] ^= (unsigned char)((t >> 8) & 0xff);
+				A[5] ^= (unsigned char)((t >> 16) & 0xff);
+				A[4] ^= (unsigned char)((t >> 24) & 0xff);
+				}
+			memcpy(B + 8, R, 8);
+			AES_decrypt(B, B, key);
+			memcpy(R, B + 8, 8);
+			}
+		}
+	if (!iv)
+		iv = default_iv;
+	if (memcmp(A, iv, 8))
+		{
+		OPENSSL_cleanse(out, inlen);
+		return 0;
+		}
+	return inlen;
+	}
+#endif

--- a/src/jose/apr_jwe.c
+++ b/src/jose/apr_jwe.c
@@ -63,6 +63,33 @@
 
 #include "apr_jose.h"
 
+/* The APR_ARRAY_PUSH and APR_ARRAY_IDX macros are from apr_tables.h from
+ * apr-1.5.2.tar.bz2
+ */
+/* It is distributed under the following license */
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* The contents of the NOTICE which pertain to apr_tables.h follow */
+/*
+ * Apache Portable Runtime
+ * Copyright (c) 2000-2015 The Apache Software Foundation.
+ * 
+ * This product includes software developed at
+ * The Apache Software Foundation (http://www.apache.org/).
+ */
 #ifndef APR_ARRAY_PUSH
 #define APR_ARRAY_PUSH(ary,type) (*((type *)apr_array_push(ary)))
 #endif
@@ -71,51 +98,10 @@
 #endif
 
 #if OPENSSL_VERSION < 0x0090809fL
-static const unsigned char default_iv[] = {
-  0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
-};
-
+/* See src/jose/aes_wrap.c */
 int AES_unwrap_key(AES_KEY *key, const unsigned char *iv,
 		unsigned char *out,
-		const unsigned char *in, unsigned int inlen)
-	{
-	unsigned char *A, B[16], *R;
-	unsigned int i, j, t;
-	inlen -= 8;
-	if (inlen & 0x7)
-		return -1;
-	if (inlen < 8)
-		return -1;
-	A = B;
-	t =  6 * (inlen >> 3);
-	memcpy(A, in, 8);
-	memcpy(out, in + 8, inlen);
-	for (j = 0; j < 6; j++)
-		{
-		R = out + inlen - 8;
-		for (i = 0; i < inlen; i += 8, t--, R -= 8)
-			{
-			A[7] ^= (unsigned char)(t & 0xff);
-			if (t > 0xff)
-				{
-				A[6] ^= (unsigned char)((t >> 8) & 0xff);
-				A[5] ^= (unsigned char)((t >> 16) & 0xff);
-				A[4] ^= (unsigned char)((t >> 24) & 0xff);
-				}
-			memcpy(B + 8, R, 8);
-			AES_decrypt(B, B, key);
-			memcpy(R, B + 8, 8);
-			}
-		}
-	if (!iv)
-		iv = default_iv;
-	if (memcmp(A, iv, 8))
-		{
-		OPENSSL_cleanse(out, inlen);
-		return 0;
-		}
-	return inlen;
-	}
+		const unsigned char *in, unsigned int inlen);
 #endif
 
 /*

--- a/src/jose/apr_jws.c
+++ b/src/jose/apr_jws.c
@@ -53,7 +53,9 @@
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 #include <openssl/rsa.h>
+#ifndef OPENSSL_NO_EC
 #include <openssl/ec.h>
+#endif
 #include <openssl/hmac.h>
 #include <openssl/err.h>
 

--- a/src/jose/apr_jwt.c
+++ b/src/jose/apr_jwt.c
@@ -59,6 +59,17 @@
 #define snprintf _snprintf
 #endif
 
+#if APU_MAJOR_VERSION == 1 && APU_MINOR_VERSION < 3
+static void
+apr_array_clear(apr_array_header_t *unpacked)
+{
+	if (unpacked) {
+		while (!apr_is_empty_array(unpacked)) {
+			apr_array_pop(unpacked);
+		}
+	}
+}
+#endif
 /*
  * assemble an error report
  */

--- a/src/jose/apr_jwt.c
+++ b/src/jose/apr_jwt.c
@@ -50,6 +50,7 @@
  * @Author: Hans Zandbelt - hzandbelt@pingidentity.com
  */
 
+#include <apr_version.h>
 #include <apr_base64.h>
 
 #include "apr_jose.h"
@@ -59,14 +60,12 @@
 #define snprintf _snprintf
 #endif
 
-#if APU_MAJOR_VERSION == 1 && APU_MINOR_VERSION < 3
+#if APR_MAJOR_VERSION == 1 && APR_MINOR_VERSION < 3
 static void
 apr_array_clear(apr_array_header_t *unpacked)
 {
 	if (unpacked) {
-		while (!apr_is_empty_array(unpacked)) {
-			apr_array_pop(unpacked);
-		}
+		unpacked->nelts = 0;
 	}
 }
 #endif

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -60,7 +60,11 @@
 #include <http_config.h>
 #include <mod_auth.h>
 
+#include "apu_version.h"
+#if APU_MAJOR_VERSION > 1 || (APU_MAJOR_VERSION == 1 && APU_MINOR_VERSION > 2)
 #include "apr_memcache.h"
+#define USE_MEMCACHE 1
+#endif
 #include "apr_shm.h"
 #include "apr_global_mutex.h"
 
@@ -290,8 +294,10 @@ typedef struct oidc_cfg {
 	char *cache_file_dir;
 	/* cache_type = file: clean interval */
 	int cache_file_clean_interval;
+#ifdef USE_MEMCACHE
 	/* cache_type= memcache: list of memcache host/port servers to use */
 	char *cache_memcache_servers;
+#endif
 	/* cache_type = shm: size of the shared memory segment (cq. max number of cached entries) */
 	int cache_shm_size_max;
 	/* cache_type = shm: maximum size in bytes of a cache entry */

--- a/test/test.c
+++ b/test/test.c
@@ -605,8 +605,8 @@ static char *test_plaintext_decrypt2(apr_pool_t *pool) {
 
 	TST_ASSERT_STR("decrypted", decrypted,
 			"You can trust us to stick with you through thick and "
-			"thin\u2013to the bitter end. And you can trust us to "
-			"keep any secret of yours\u2013closer than you keep it "
+			"thin\342\200\223to the bitter end. And you can trust us to "
+			"keep any secret of yours\342\200\223closer than you keep it "
 			"yourself. But you cannot trust us to let you face trouble "
 			"alone, and go off without a word. We are your friends, Frodo.");
 


### PR DESCRIPTION
These patches do some preprocessor checks to avoid and/or implement parts of OpenSSL and APR-1 that aren't present in the very old version in Red Hat 5-based distributions. It also replaces the unicode literal en-dash in the test with an octal sequence that the older compilers seem more happy about.

For OpenSSL, this conditionally adds AES_unwrap_key and disables the ec cipher related-code if they are not available.

For APR-1, this adds a conditional check for memcache and adds some missing apr_tables.h bits.

The jansson dependency must still be met somehow by the builder of this module, but its still easier to build than it was before.