### PR TITLE
Support subdomain cookies in OIDCCookieDomain checks.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1430,18 +1430,10 @@ static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 	}
 
 	if (c->cookie_domain != NULL) {
-		char *p = NULL;
-		// Skip past a cookie_domain that starts with a ".", ASCII 46
-		char *check_cookie = c->cookie_domain;
-		if (check_cookie[0] == 46) {
-			p = strstr(r_uri.hostname, ++check_cookie);
-		} else {
-			p = strstr(r_uri.hostname, check_cookie);
-		}
-		if ((p == NULL) || (apr_strnatcmp(check_cookie, p) != 0)) {
+		if (!oidc_util_cookie_domain_valid(r_uri.hostname, c->cookie_domain)) {
 			oidc_serror(s,
-					"the domain (%s) configured in OIDCCookieDomain does not match the URL hostname (%s) of the configured OIDCRedirectURI (%s): setting \"state\" and \"session\" cookies will not work!",
-					check_cookie, r_uri.hostname, c->redirect_uri);
+				"the domain (%s) configured in OIDCCookieDomain does not match the URL hostname (%s) of the configured OIDCRedirectURI (%s): setting \"state\" and \"session\" cookies will not work!",
+				c->cookie_domain, r_uri.hostname, c->redirect_uri);
 			return HTTP_INTERNAL_SERVER_ERROR;
 		}
 	}

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -1509,18 +1509,10 @@ static int oidc_authenticate_user(request_rec *r, oidc_cfg *c,
 			}
 		}
 	} else {
-		char *p = NULL;
-		// Skip past a cookie_domain that starts with a ".", ASCII 46
-		char *check_cookie = c->cookie_domain;
-		if (check_cookie[0] == 46) {
-			p = strstr(o_uri.hostname, ++check_cookie);
-		} else {
-			p = strstr(o_uri.hostname, check_cookie);
-		}
-		if ((p == NULL) || (apr_strnatcmp(check_cookie, p) != 0)) {
+		if (!oidc_util_cookie_domain_valid(r_uri.hostname, c->cookie_domain)) {
 			oidc_error(r,
-					"the domain (%s) configured in OIDCCookieDomain does not match the URL hostname (%s) of the URL being accessed (%s): setting \"state\" and \"session\" cookies will not work!!",
-					check_cookie, o_uri.hostname, original_url);
+				"the domain (%s) configured in OIDCCookieDomain does not match the URL hostname (%s) of the URL being accessed (%s): setting \"state\" and \"session\" cookies will not work!!",
+				c->cookie_domain, o_uri.hostname, original_url);
 			return HTTP_INTERNAL_SERVER_ERROR;
 		}
 	}

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -1509,11 +1509,18 @@ static int oidc_authenticate_user(request_rec *r, oidc_cfg *c,
 			}
 		}
 	} else {
-		char *p = strstr(o_uri.hostname, c->cookie_domain);
-		if ((p == NULL) || (apr_strnatcmp(c->cookie_domain, p) != 0)) {
+		char *p = NULL;
+		// Skip past a cookie_domain that starts with a ".", ASCII 46
+		char *check_cookie = c->cookie_domain;
+		if (check_cookie[0] == 46) {
+			p = strstr(o_uri.hostname, ++check_cookie);
+		} else {
+			p = strstr(o_uri.hostname, check_cookie);
+		}
+		if ((p == NULL) || (apr_strnatcmp(check_cookie, p) != 0)) {
 			oidc_error(r,
 					"the domain (%s) configured in OIDCCookieDomain does not match the URL hostname (%s) of the URL being accessed (%s): setting \"state\" and \"session\" cookies will not work!!",
-					c->cookie_domain, o_uri.hostname, original_url);
+					check_cookie, o_uri.hostname, original_url);
 			return HTTP_INTERNAL_SERVER_ERROR;
 		}
 	}

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -435,6 +435,7 @@ apr_hash_t * oidc_util_merge_symmetric_key(apr_pool_t *pool, apr_hash_t *private
 apr_hash_t * oidc_util_merge_key_sets(apr_pool_t *pool, apr_hash_t *k1, apr_hash_t *k2);
 apr_byte_t oidc_util_regexp_first_match(apr_pool_t *pool, const char *input, const char *regexp, char **output, char **error_str);
 apr_byte_t oidc_util_json_merge(json_t *src, json_t *dst);
+int oidc_util_cookie_domain_valid(const char *hostname, char *cookie_domain);
 
 // oidc_crypto.c
 unsigned char *oidc_crypto_aes_encrypt(request_rec *r, oidc_cfg *cfg, unsigned char *plaintext, int *len);

--- a/src/util.c
+++ b/src/util.c
@@ -1576,3 +1576,19 @@ apr_byte_t oidc_util_regexp_first_match(apr_pool_t *pool, const char *input,
 
 	return TRUE;
 }
+
+int oidc_util_cookie_domain_valid(const char *hostname, char *cookie_domain) {
+	char *p = NULL;
+	char *check_cookie = cookie_domain;
+	// Skip past the first char of a cookie_domain that starts
+	// with a ".", ASCII 46
+	if (check_cookie[0] == 46) {
+		p = strstr(hostname, ++check_cookie);
+	} else {
+		p = strstr(hostname, check_cookie);
+	}
+	if ((p == NULL) || (apr_strnatcmp(check_cookie, p) != 0)) {
+		return FALSE;
+	}
+	return TRUE;
+}


### PR DESCRIPTION
A small patch to skip past a leading period in OIDCCookieDomain when checking it's value.

Setting an OIDCCookieDomain with a leading period allows the session cookie to be shared across subdomains.