### PR TITLE
PASS mode anonymous access for Apache 2.4

### DIFF
--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2681,6 +2681,15 @@ authz_status oidc_authz_checker(request_rec *r, const char *require_args, const 
  */
 int oidc_auth_checker(request_rec *r) {
 
+	/* check for anonymous access and PASS mode */
+	if (r->user != NULL && strlen(r->user) == 0) {
+		r->user = NULL;
+		/* get a handle to the directory config */
+		oidc_dir_cfg *dir_cfg = ap_get_module_config(r->per_dir_config,
+				&auth_openidc_module);
+		if (dir_cfg->unauth_action == PASS) return OK;
+	}
+
 	/* get the set of claims from the request state (they've been set in the authentication part earlier */
 	json_t *claims = NULL, *id_token = NULL;
 	oidc_authz_get_claims_and_idtoken(r, &claims, &id_token);

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2569,6 +2569,7 @@ static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *c) {
 		case RETURN401:
 			return HTTP_UNAUTHORIZED;
 		case PASS:
+			r->user = "";
 			return OK;
 		case AUTHENTICATE:
 			/* if this is a Javascript path we won't redirect the user and create a state cookie */
@@ -2641,6 +2642,15 @@ static void oidc_authz_get_claims_and_idtoken(request_rec *r, json_t **claims,
  * handles both OpenID Connect or OAuth 2.0 in the same way, based on the claims stored in the session
  */
 authz_status oidc_authz_checker(request_rec *r, const char *require_args, const void *parsed_require_args) {
+
+	/* check for anonymous access and PASS mode */
+	if (r->user != NULL && strlen(r->user) == 0) {
+		r->user = NULL;
+		/* get a handle to the directory config */
+		oidc_dir_cfg *dir_cfg = ap_get_module_config(r->per_dir_config,
+				&auth_openidc_module);
+		if (dir_cfg->unauth_action == PASS) return AUTHZ_GRANTED;
+	}
 
 	/* get the set of claims from the request state (they've been set in the authentication part earlier */
 	json_t *claims = NULL, *id_token = NULL;


### PR DESCRIPTION
I couldn't get anonymous access to work without this patch using Apache 2.4.  PASS mode worked fine when authenticated, but got a 500 error when unauthenticated.

With this patch, all that is required in Apache config is a block like:
```
<Location /anon>
    OIDCUnAuthAction PASS
</Location>
```

If I've just overlooked something and PASS mode should work with Apache 2.4 without this patch, please advise the configuration required to get it to work.  As always, please let me know if you like the idea of the patch but would like some refactoring.

Thanks.