### PR TITLE
Support relative RedirectURIs

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -239,21 +239,22 @@ static const char *oidc_set_url_slot(cmd_parms *cmd, void *ptr, const char *arg)
 }
 
 /*
- * set a relative HTTPS/HTTP value in the server config
+ * set a relative or absolute URL value in the server config
  */
-static const char *oidc_set_redirect_url_slot(cmd_parms *cmd, void *ptr, const char *arg) {
+static const char *oidc_set_relative_or_absolute_url_slot(cmd_parms *cmd, void *ptr, const char *arg) {
 	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
 			cmd->server->module_config, &auth_openidc_module);
   if (arg[0] == '/') {
-		// Relative RedirectURI
+		// relative uri
 		apr_uri_t uri;
 		if (apr_uri_parse(cmd->pool, arg, &uri) != APR_SUCCESS) {
-			return apr_psprintf(cmd->pool, "'%s' cannot be parsed as a relative URL", arg);
+			const char *rv = apr_psprintf(cmd->pool, "cannot parse '%s' as relative URI", arg);
+			return OIDC_CONFIG_DIR_RV(cmd, rv);
 		} else {
 			return ap_set_string_slot(cmd, cfg, arg);
 		}
 	} else {
-		// Absolute RedirectURI
+		// absolute uri
 		return oidc_set_url_slot_type(cmd, cfg, arg, NULL);
 	}
 }
@@ -753,7 +754,6 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->merged = FALSE;
 
 	c->redirect_uri = NULL;
-	c->redirect_uri_is_relative = FALSE;
 	c->default_sso_url = NULL;
 	c->default_slo_url = NULL;
 	c->public_keys = NULL;
@@ -882,10 +882,6 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 
 	c->redirect_uri =
 			add->redirect_uri != NULL ? add->redirect_uri : base->redirect_uri;
-
-	if (c->redirect_uri != NULL) {
-		c->redirect_uri_is_relative = (c->redirect_uri[0] == '/');
-	}
 
 	c->default_sso_url =
 			add->default_sso_url != NULL ?
@@ -1455,6 +1451,7 @@ static int oidc_check_config_error(server_rec *s, const char *config_str) {
 static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 
 	apr_uri_t r_uri;
+	int redirect_uri_is_relative;
 
 	if ((c->metadata_dir == NULL) && (c->provider.issuer == NULL)
 			&& (c->provider.metadata_url == NULL)) {
@@ -1465,6 +1462,8 @@ static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 
 	if (c->redirect_uri == NULL)
 		return oidc_check_config_error(s, "OIDCRedirectURI");
+	redirect_uri_is_relative = (c->redirect_uri[0] == '/');
+
 	if (c->crypto_passphrase == NULL)
 		return oidc_check_config_error(s, "OIDCCryptoPassphrase");
 
@@ -1494,7 +1493,7 @@ static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 	}
 
 	apr_uri_parse(s->process->pconf, c->redirect_uri, &r_uri);
-	if (!c->redirect_uri_is_relative) {
+	if (!redirect_uri_is_relative) {
 		if (apr_strnatcmp(r_uri.scheme, "https") != 0) {
 			oidc_swarn(s,
 					"the URL scheme (%s) of the configured OIDCRedirectURI SHOULD be \"https\" for security reasons (moreover: some Providers may reject non-HTTPS URLs)",
@@ -1503,7 +1502,7 @@ static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 	}
 
 	if (c->cookie_domain != NULL) {
-		if (c->redirect_uri_is_relative) {
+		if (redirect_uri_is_relative) {
 				oidc_swarn(s,	"if the configured OIDCRedirectURI is relative, OIDCCookieDomain SHOULD be empty");
 		} else if (!oidc_util_cookie_domain_valid(r_uri.hostname, c->cookie_domain)) {
 			oidc_serror(s,
@@ -2010,7 +2009,7 @@ const command_rec oidc_config_cmds[] = {
 				RSRC_CONF,
 				"TLS client certificate private key used for calls to OpenID Connect OP token endpoint."),
 
-		AP_INIT_TAKE1("OIDCRedirectURI", oidc_set_redirect_url_slot,
+		AP_INIT_TAKE1("OIDCRedirectURI", oidc_set_relative_or_absolute_url_slot,
 				(void *)APR_OFFSETOF(oidc_cfg, redirect_uri),
 				RSRC_CONF,
 				"Define the Redirect URI (e.g.: https://localhost:9031/protected/example/)"),

--- a/src/config.c
+++ b/src/config.c
@@ -882,7 +882,6 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 
 	c->redirect_uri =
 			add->redirect_uri != NULL ? add->redirect_uri : base->redirect_uri;
-
 	c->default_sso_url =
 			add->default_sso_url != NULL ?
 					add->default_sso_url : base->default_sso_url;

--- a/src/config.c
+++ b/src/config.c
@@ -1451,7 +1451,7 @@ static int oidc_check_config_error(server_rec *s, const char *config_str) {
 static int oidc_check_config_openid_openidc(server_rec *s, oidc_cfg *c) {
 
 	apr_uri_t r_uri;
-	int redirect_uri_is_relative;
+	apr_byte_t redirect_uri_is_relative;
 
 	if ((c->metadata_dir == NULL) && (c->provider.issuer == NULL)
 			&& (c->provider.metadata_url == NULL)) {

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -475,7 +475,7 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 	json_object_set_new(data, "client_name",
 			json_string(provider->client_name));
 	json_object_set_new(data, "redirect_uris",
-			json_pack("[s]", cfg->redirect_uri));
+			json_pack("[s]", oidc_get_redirect_uri(r, cfg)));
 
 	json_t *response_types = json_array();
 	apr_array_header_t *flows = oidc_proto_supported_flows(r->pool);
@@ -503,7 +503,7 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 		json_object_set_new(data, "jwks_uri",
 				json_string(
 						apr_psprintf(r->pool, "%s?jwks=rsa",
-								cfg->redirect_uri)));
+								oidc_get_redirect_uri(r, cfg))));
 	}
 
 	if (provider->id_token_signed_response_alg != NULL) {
@@ -533,10 +533,10 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 	}
 
 	json_object_set_new(data, "initiate_login_uri",
-			json_string(cfg->redirect_uri));
+			json_string(oidc_get_redirect_uri(r, cfg)));
 
 	json_object_set_new(data, "frontchannel_logout_uri",
-			json_string(apr_psprintf(r->pool, "%s?logout=%s", cfg->redirect_uri,
+			json_string(apr_psprintf(r->pool, "%s?logout=%s", oidc_get_redirect_uri(r, cfg),
 					OIDC_GET_STYLE_LOGOUT_PARAM_VALUE)));
 
 	if (cfg->default_slo_url != NULL) {

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2934,22 +2934,6 @@ int oidc_handle_redirect_uri_request(request_rec *r, oidc_cfg *c,
 }
 
 /*
- * determine absolute redirect uri
- */
-const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *cfg) {
-
-	char *redirect_uri = cfg->redirect_uri;
-
-	if ((redirect_uri != NULL) && (redirect_uri[0] == '/')) {
-		// relative redirect uri
-		// TODO: we are forcing https here because the actual scheme is harder to get
-		redirect_uri = apr_pstrcat(r->pool, "https://", r->hostname, cfg->redirect_uri, (char *)NULL);
-		oidc_debug(r, "determined absolute redirect uri: %s", redirect_uri);
-	}
-	return redirect_uri;
-}
-
-/*
  * main routine: handle OpenID Connect authentication
  */
 static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *c) {

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -2935,7 +2935,18 @@ int oidc_handle_redirect_uri_request(request_rec *r, oidc_cfg *c,
 /*
  * main routine: handle OpenID Connect authentication
  */
-static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *c) {
+static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *cc) {
+
+	oidc_cfg *c = apr_pcalloc(r->pool, sizeof(oidc_cfg));
+	memcpy(c, cc, sizeof(oidc_cfg));
+
+	if (c->redirect_uri_is_relative) {
+
+		c->redirect_uri = apr_pstrcat(r->pool, "https://", r->hostname, cc->redirect_uri, (char *)NULL);
+		oidc_debug(r,
+				"i have constructed the following redirect uri, my master: %s",
+				c->redirect_uri);
+}
 
 	if (c->redirect_uri == NULL) {
 		oidc_error(r,

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -375,7 +375,7 @@ static const char *oidc_original_request_method(request_rec *r, oidc_cfg *cfg,
 
 	char *m = NULL;
 	if ((handle_discovery_response == TRUE)
-			&& (oidc_util_request_matches_url(r, cfg->redirect_uri))
+			&& (oidc_util_request_matches_url(r, oidc_get_redirect_uri(r, cfg)))
 			&& (oidc_is_discovery_response(r, cfg))) {
 		oidc_util_get_request_parameter(r, OIDC_DISC_RM_PARAM, &m);
 		if (m != NULL)
@@ -1491,7 +1491,7 @@ static int oidc_session_redirect_parent_window_to_logout(request_rec *r,
 	char *java_script = apr_psprintf(r->pool,
 			"    <script type=\"text/javascript\">\n"
 			"      window.top.location.href = '%s?session=logout';\n"
-			"    </script>\n", c->redirect_uri);
+			"    </script>\n", oidc_get_redirect_uri(r, c));
 
 	return oidc_util_html_send(r, "Redirecting...", java_script, NULL, NULL,
 			DONE);
@@ -1984,7 +1984,7 @@ static int oidc_discovery(request_rec *r, oidc_cfg *cfg) {
 						OIDC_DISC_RT_PARAM, oidc_util_escape_string(r, current_url),
 						OIDC_DISC_RM_PARAM, method,
 						OIDC_DISC_CB_PARAM,
-						oidc_util_escape_string(r, cfg->redirect_uri),
+						oidc_util_escape_string(r, oidc_get_redirect_uri(r, cfg)),
 						OIDC_CSRF_NAME, oidc_util_escape_string(r, csrf));
 
 		/* log what we're about to do */
@@ -2031,7 +2031,7 @@ static int oidc_discovery(request_rec *r, oidc_cfg *cfg) {
 		s =
 				apr_psprintf(r->pool,
 						"%s<p><a href=\"%s?%s=%s&amp;%s=%s&amp;%s=%s&amp;%s=%s\">%s</a></p>\n",
-						s, cfg->redirect_uri, OIDC_DISC_OP_PARAM,
+						s, oidc_get_redirect_uri(r, cfg), OIDC_DISC_OP_PARAM,
 						oidc_util_escape_string(r, issuer),
 						OIDC_DISC_RT_PARAM,
 						oidc_util_escape_string(r, current_url),
@@ -2041,7 +2041,7 @@ static int oidc_discovery(request_rec *r, oidc_cfg *cfg) {
 
 	/* add an option to enter an account or issuer name for dynamic OP discovery */
 	s = apr_psprintf(r->pool, "%s<form method=\"get\" action=\"%s\">\n", s,
-			cfg->redirect_uri);
+			oidc_get_redirect_uri(r, cfg));
 	s = apr_psprintf(r->pool,
 			"%s<p><input type=\"hidden\" name=\"%s\" value=\"%s\"><p>\n", s,
 			OIDC_DISC_RT_PARAM, current_url);
@@ -2154,7 +2154,7 @@ static int oidc_authenticate_user(request_rec *r, oidc_cfg *c,
 	apr_uri_t r_uri;
 	memset(&r_uri, 0, sizeof(apr_uri_t));
 	apr_uri_parse(r->pool, original_url, &o_uri);
-	apr_uri_parse(r->pool, c->redirect_uri, &r_uri);
+	apr_uri_parse(r->pool, oidc_get_redirect_uri(r, c), &r_uri);
 	if ((apr_strnatcmp(o_uri.scheme, r_uri.scheme) != 0)
 			&& (apr_strnatcmp(r_uri.scheme, "https") == 0)) {
 		oidc_error(r,
@@ -2185,8 +2185,8 @@ static int oidc_authenticate_user(request_rec *r, oidc_cfg *c,
 	/* send off to the OpenID Connect Provider */
 	// TODO: maybe show intermediate/progress screen "redirecting to"
 	return oidc_proto_authorization_request(r, provider, login_hint,
-			c->redirect_uri, state, proto_state, id_token_hint, code_challenge,
-			auth_request_params);
+			oidc_get_redirect_uri(r, c), state, proto_state, id_token_hint,
+			code_challenge, auth_request_params);
 }
 
 /*
@@ -2205,7 +2205,7 @@ static int oidc_target_link_uri_matches_configuration(request_rec *r,
 	}
 
 	apr_uri_t r_uri;
-	apr_uri_parse(r->pool, cfg->redirect_uri, &r_uri);
+	apr_uri_parse(r->pool, oidc_get_redirect_uri(r, cfg), &r_uri);
 
 	if (cfg->cookie_domain == NULL) {
 		/* cookie_domain set: see if the target_link_uri matches the redirect_uri host (because the session cookie will be set host-wide) */
@@ -2649,9 +2649,10 @@ static int oidc_handle_session_management_iframe_rp(request_rec *r, oidc_cfg *c,
 	if (s_poll_interval == NULL)
 		s_poll_interval = "3000";
 
+	const char *redirect_uri = oidc_get_redirect_uri(r, c);
 	java_script = apr_psprintf(r->pool, java_script, origin, client_id,
-			session_state, op_iframe_id, s_poll_interval, c->redirect_uri,
-			c->redirect_uri);
+			session_state, op_iframe_id, s_poll_interval, redirect_uri,
+			redirect_uri);
 
 	return oidc_util_html_send(r, NULL, java_script, "setTimer", NULL, DONE);
 }
@@ -2713,7 +2714,7 @@ static int oidc_handle_session_management(request_rec *r, oidc_cfg *c,
 		if ((session->remote_user != NULL) && (provider != NULL)) {
 			return oidc_authenticate_user(r, c, provider,
 					apr_psprintf(r->pool, "%s?session=iframe_rp",
-							c->redirect_uri), NULL, id_token_hint, "none", NULL);
+							oidc_get_redirect_uri(r, c)), NULL, id_token_hint, "none", NULL);
 		}
 		oidc_debug(r,
 				"[session=check] calling oidc_handle_logout_request because no session found.");
@@ -2933,20 +2934,25 @@ int oidc_handle_redirect_uri_request(request_rec *r, oidc_cfg *c,
 }
 
 /*
+ * determine absolute redirect uri
+ */
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *cfg) {
+
+	char *redirect_uri = cfg->redirect_uri;
+
+	if ((redirect_uri != NULL) && (redirect_uri[0] == '/')) {
+		// relative redirect uri
+		// TODO: we are forcing https here because the actual scheme is harder to get
+		redirect_uri = apr_pstrcat(r->pool, "https://", r->hostname, cfg->redirect_uri, (char *)NULL);
+		oidc_debug(r, "determined absolute redirect uri: %s", redirect_uri);
+	}
+	return redirect_uri;
+}
+
+/*
  * main routine: handle OpenID Connect authentication
  */
-static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *cc) {
-
-	oidc_cfg *c = apr_pcalloc(r->pool, sizeof(oidc_cfg));
-	memcpy(c, cc, sizeof(oidc_cfg));
-
-	if (c->redirect_uri_is_relative) {
-
-		c->redirect_uri = apr_pstrcat(r->pool, "https://", r->hostname, cc->redirect_uri, (char *)NULL);
-		oidc_debug(r,
-				"i have constructed the following redirect uri, my master: %s",
-				c->redirect_uri);
-}
+static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *c) {
 
 	if (c->redirect_uri == NULL) {
 		oidc_error(r,
@@ -2964,7 +2970,7 @@ static int oidc_check_userid_openidc(request_rec *r, oidc_cfg *cc) {
 		oidc_session_load(r, &session);
 
 		/* see if the initial request is to the redirect URI; this handles potential logout too */
-		if (oidc_util_request_matches_url(r, c->redirect_uri)) {
+		if (oidc_util_request_matches_url(r, oidc_get_redirect_uri(r, c))) {
 
 			/* handle request to the redirect_uri */
 			rc = oidc_handle_redirect_uri_request(r, c, session);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -310,6 +310,10 @@ typedef struct oidc_cfg {
 
 	/* the redirect URI as configured with the OpenID Connect OP's that we talk to */
 	char *redirect_uri;
+
+	/* whether the redirect URI is relative */
+	int redirect_uri_is_relative;
+
 	/* (optional) default URL for 3rd-party initiated SSO */
 	char *default_sso_url;
 	/* (optional) default URL to go to after logout */

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -310,7 +310,6 @@ typedef struct oidc_cfg {
 
 	/* the redirect URI as configured with the OpenID Connect OP's that we talk to */
 	char *redirect_uri;
-
 	/* (optional) default URL for 3rd-party initiated SSO */
 	char *default_sso_url;
 	/* (optional) default URL to go to after logout */

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -311,9 +311,6 @@ typedef struct oidc_cfg {
 	/* the redirect URI as configured with the OpenID Connect OP's that we talk to */
 	char *redirect_uri;
 
-	/* whether the redirect URI is relative */
-	int redirect_uri_is_relative;
-
 	/* (optional) default URL for 3rd-party initiated SSO */
 	char *default_sso_url;
 	/* (optional) default URL to go to after logout */
@@ -395,6 +392,7 @@ void oidc_scrub_headers(request_rec *r);
 
 // oidc_oauth
 int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c);
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *c);
 
 // oidc_proto.c
 char *oidc_proto_peek_jwt_header(request_rec *r, const char *jwt, char **alg);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -391,7 +391,6 @@ void oidc_scrub_headers(request_rec *r);
 
 // oidc_oauth
 int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c);
-const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *c);
 
 // oidc_proto.c
 char *oidc_proto_peek_jwt_header(request_rec *r, const char *jwt, char **alg);
@@ -460,6 +459,7 @@ int oidc_base64url_encode(request_rec *r, char **dst, const char *src, int src_l
 int oidc_base64url_decode(apr_pool_t *pool, char **dst, const char *src);
 const char *oidc_get_current_url_host(request_rec *r);
 char *oidc_get_current_url(request_rec *r);
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *c);
 char *oidc_url_encode(const request_rec *r, const char *str, const char *charsToEncode);
 char *oidc_normalize_header_name(const request_rec *r, const char *str);
 void oidc_util_set_cookie(request_rec *r, const char *cookieName, const char *cookieValue, apr_time_t expires);

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -609,7 +609,7 @@ int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c) {
 
 		/* check if this is a request for the public (encryption) keys */
 	} else if ((c->redirect_uri != NULL)
-			&& (oidc_util_request_matches_url(r, c->redirect_uri))) {
+			&& (oidc_util_request_matches_url(r, oidc_get_redirect_uri(r, c)))) {
 
 		if (oidc_util_request_has_parameter(r, "jwks")) {
 

--- a/src/proto.c
+++ b/src/proto.c
@@ -1353,7 +1353,7 @@ static apr_byte_t oidc_proto_resolve_code(request_rec *r, oidc_cfg *cfg,
 	apr_table_t *params = apr_table_make(r->pool, 5);
 	apr_table_addn(params, "grant_type", "authorization_code");
 	apr_table_addn(params, "code", code);
-	apr_table_addn(params, "redirect_uri", cfg->redirect_uri);
+	apr_table_addn(params, "redirect_uri", oidc_get_redirect_uri(r, cfg));
 
 	if (code_verifier)
 		apr_table_addn(params, "code_verifier", code_verifier);

--- a/src/util.c
+++ b/src/util.c
@@ -449,6 +449,29 @@ char *oidc_get_current_url(request_rec *r) {
 	return url;
 }
 
+/*
+ * determine absolute redirect uri
+ */
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *cfg) {
+
+	char *redirect_uri = cfg->redirect_uri;
+
+	if ((redirect_uri != NULL) && (redirect_uri[0] == '/')) {
+		// relative redirect uri
+
+		const char *scheme_str = oidc_get_current_url_scheme(r);
+		const char *host_str = oidc_get_current_url_host(r);
+		const char *port_str = oidc_get_current_url_port(r, scheme_str);
+		port_str = port_str ? apr_psprintf(r->pool, ":%s", port_str) : "";
+
+		redirect_uri = apr_pstrcat(r->pool, scheme_str, "://", host_str, port_str,
+				cfg->redirect_uri, NULL);
+
+		oidc_debug(r, "determined absolute redirect uri: %s", redirect_uri);
+	}
+	return redirect_uri;
+}
+
 /* buffer to hold HTTP call responses */
 typedef struct oidc_curl_buffer {
 	request_rec *r;


### PR DESCRIPTION
_This PR may be for discussion only: I'd squash the commits into one before merging this._

**This PR implements support for relative RedirectURIs in mod_auth_openidc.**

It does so by offering a new function `oidc_get_redirect_uri` that is to be used instead of direct access to the attribute `cfg->redirect_uri`:
- If the configuration specifies an absolute RedirectURI it returns this URL unchanged.
- If the configuration specifies a relative RedirectURI, it uses values from the current request to assemble an actual absolute RedirectURI suited for the currently requested URL.

Please review my proposed changes most critically, it's been a while since I wrote actual C code.

Open questions:
- I'm pretty unsure about the `const` modifiers for function parameters and return values - could you double check whether I used those correctly?
- Was it OK to change all occurences of `cfg->redirect_uri` to the function call, except for those where the value is just checked for `NULL`?