### PR TITLE
Support relative RedirectURIs in mod_auth_openidc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+04/20/2017
+- support relative RedirectURIs
+  - add helper function oidc_get_redirect_uri
+
 04/08/2017
 - fix potential crash on prefork process exit when used with Redis cache backend (3x)
 - bump to 2.2.1rc3

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -477,7 +477,7 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 	json_object_set_new(data, "client_name",
 			json_string(provider->client_name));
 	json_object_set_new(data, "redirect_uris",
-			json_pack("[s]", cfg->redirect_uri));
+			json_pack("[s]", oidc_get_redirect_uri(r, cfg)));
 
 	json_t *response_types = json_array();
 	apr_array_header_t *flows = oidc_proto_supported_flows(r->pool);
@@ -505,7 +505,7 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 		json_object_set_new(data, "jwks_uri",
 				json_string(
 						apr_psprintf(r->pool, "%s?jwks=rsa",
-								cfg->redirect_uri)));
+								oidc_get_redirect_uri(r, cfg))));
 	}
 
 	if (provider->id_token_signed_response_alg != NULL) {
@@ -535,10 +535,10 @@ static apr_byte_t oidc_metadata_client_register(request_rec *r, oidc_cfg *cfg,
 	}
 
 	json_object_set_new(data, "initiate_login_uri",
-			json_string(cfg->redirect_uri));
+			json_string(oidc_get_redirect_uri(r, cfg)));
 
 	json_object_set_new(data, "frontchannel_logout_uri",
-			json_string(apr_psprintf(r->pool, "%s?logout=%s", cfg->redirect_uri,
+			json_string(apr_psprintf(r->pool, "%s?logout=%s", oidc_get_redirect_uri(r, cfg),
 					OIDC_GET_STYLE_LOGOUT_PARAM_VALUE)));
 
 	if (cfg->default_slo_url != NULL) {

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -588,6 +588,7 @@ int oidc_base64url_encode(request_rec *r, char **dst, const char *src, int src_l
 int oidc_base64url_decode(apr_pool_t *pool, char **dst, const char *src);
 const char *oidc_get_current_url_host(request_rec *r);
 char *oidc_get_current_url(request_rec *r);
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *c);
 char *oidc_url_encode(const request_rec *r, const char *str, const char *charsToEncode);
 char *oidc_normalize_header_name(const request_rec *r, const char *str);
 void oidc_util_set_cookie(request_rec *r, const char *cookieName, const char *cookieValue, apr_time_t expires, const char *ext);

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -617,7 +617,7 @@ int oidc_oauth_check_userid(request_rec *r, oidc_cfg *c) {
 
 		/* check if this is a request for the public (encryption) keys */
 	} else if ((c->redirect_uri != NULL)
-			&& (oidc_util_request_matches_url(r, c->redirect_uri))) {
+			&& (oidc_util_request_matches_url(r, oidc_get_redirect_uri(r, c)))) {
 
 		if (oidc_util_request_has_parameter(r, "jwks")) {
 

--- a/src/proto.c
+++ b/src/proto.c
@@ -1716,7 +1716,7 @@ static apr_byte_t oidc_proto_resolve_code(request_rec *r, oidc_cfg *cfg,
 	apr_table_addn(params, OIDC_PROTO_GRANT_TYPE,
 			OIDC_PROTO_GRANT_TYPE_AUTHZ_CODE);
 	apr_table_addn(params, OIDC_PROTO_CODE, code);
-	apr_table_addn(params, OIDC_PROTO_REDIRECT_URI, cfg->redirect_uri);
+	apr_table_addn(params, OIDC_PROTO_REDIRECT_URI, oidc_get_redirect_uri(r, cfg));
 
 	if (code_verifier)
 		apr_table_addn(params, OIDC_PROTO_CODE_VERIFIER, code_verifier);

--- a/src/util.c
+++ b/src/util.c
@@ -431,22 +431,50 @@ const char *oidc_get_current_url_host(request_rec *r) {
 }
 
 /*
- * get the URL that is currently being accessed
+ * get the base part of the current URL (scheme + host (+ port))
  */
-char *oidc_get_current_url(request_rec *r) {
+const char *oidc_get_current_url_base(request_rec *r) {
 
 	const char *scheme_str = oidc_get_current_url_scheme(r);
 	const char *host_str = oidc_get_current_url_host(r);
 	const char *port_str = oidc_get_current_url_port(r, scheme_str);
 	port_str = port_str ? apr_psprintf(r->pool, ":%s", port_str) : "";
 
-	char *url = apr_pstrcat(r->pool, scheme_str, "://", host_str, port_str,
+	char *url = apr_pstrcat(r->pool, scheme_str, "://", host_str, port_str, NULL);
+
+	return url;
+}
+
+/*
+ * get the URL that is currently being accessed
+ */
+char *oidc_get_current_url(request_rec *r) {
+
+	char *url = apr_pstrcat(r->pool, oidc_get_current_url_base(r),
 			r->uri, (r->args != NULL && *r->args != '\0' ? "?" : ""), r->args,
 			NULL);
 
 	oidc_debug(r, "current URL '%s'", url);
 
 	return url;
+}
+
+/*
+ * determine absolute redirect uri
+ */
+const char *oidc_get_redirect_uri(request_rec *r, oidc_cfg *cfg) {
+
+	char *redirect_uri = cfg->redirect_uri;
+
+	if ((redirect_uri != NULL) && (redirect_uri[0] == '/')) {
+		// relative redirect uri
+
+		redirect_uri = apr_pstrcat(r->pool, oidc_get_current_url_base(r),
+				cfg->redirect_uri, NULL);
+
+		oidc_debug(r, "determined absolute redirect uri: %s", redirect_uri);
+	}
+	return redirect_uri;
 }
 
 /* buffer to hold HTTP call responses */


### PR DESCRIPTION
**This PR implements support for relative RedirectURIs in mod_auth_openidc.**

It does so by offering a new function `oidc_get_redirect_uri` that is to
be used instead of direct access to the attribute `cfg->redirect_uri`:
- If the configuration specifies an absolute RedirectURI it returns this
  URL unchanged.
- If the configuration specifies a relative RedirectURI, it uses
  values from the current request to assemble an actual absolute
  RedirectURI suited for the currently requested URL.

Some direct accesses to `cfg->redirect_uri` where left unchanged where
they only check for NULL.

The `oidc_get_redirect_uri` lives in utils.c and shares some factored
out code in `oidc_get_current_url_base` with `oidc_get_current_url`.

Closes #200.