### PR TITLE
Add possibility to send Authorization Request as "request" instead of "request_uri"

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -736,7 +736,17 @@
 
 # (Optional)
 # Request Object/URI settings. For example:
-# "{ \"copy_from_request\": [ \"claims\", \"response_type\", \"response_mode\", \"login_hint\", \"id_token_hint\", \"nonce\", \"state\", \"redirect_uri\", \"scope\", \"client_id\" ], \"static\": { \"some\": \"value\", \"some_nested\": { \"some_array\": [ 1,2,3] } }, \"crypto\": { \"sign_alg\": \"HS256\", \"crypt_alg\": \"A256KW\", \"crypt_enc\": \"A256CBC-HS512\" }, \"url\": \"https://www.pingidentity.nl/protected/\" }"
+# "{ \"copy_from_request\": [ \"claims\", \"response_type\", \"response_mode\", \"login_hint\", \"id_token_hint\", \"nonce\", \"state\", \"redirect_uri\", \"scope\", \"client_id\" ], \"static\": { \"some\": \"value\", \"some_nested\": { \"some_array\": [ 1,2,3] } }, \"crypto\": { \"sign_alg\": \"HS256\", \"crypt_alg\": \"A256KW\", \"crypt_enc\": \"A256CBC-HS512\" }, \"url\": \"https://www.pingidentity.nl/protected/\", \"request_object_type\" : \"request\" }"
+# Parameters:
+#   copy_from_request (array)    : array of parameters copied from request
+#   static (object)              : parameter value is merged to the request object
+#   crypto (object)              : defines cryptography used to create request object
+#     sign_alg (string)          : algorithm used to sign request object (JWS alg parameter)
+#     crypt_alg (string)         : algorithm used to encrypt CEK of request object (JWE alg parameter)
+#     crypt_enc (string)         : algorithm used to encrypt request object (JWE enc parameter)
+#   url (string)                 : use this url instead of redirect_uri for request_uri
+#   request_object_type (string) : parameter used for sending authorization request object
+#                                 "request_uri" (default) or "request"
 # NB: this can be overridden on a per-OP basis in the .conf file using the key: request_object
 #OIDCRequestObject <stringified-JSON-object>
 

--- a/src/authz.c
+++ b/src/authz.c
@@ -229,6 +229,21 @@ apr_byte_t oidc_authz_match_claim(request_rec *r,
 
 			if (oidc_authz_match_expression(r, spec_c, val) == TRUE)
 				return TRUE;
+
+			/* dot means child nodes must be evaluated */
+		} else if (!(*attr_c) && (*spec_c) == '.') {
+
+			/* skip the dot */
+			spec_c++;
+
+			if (!json_is_object(val)) {
+				oidc_warn(r, "\"%s\" matched, and child nodes should be evaluated, but value is not an object.", key);
+				return FALSE;
+			}
+
+			oidc_debug(r, "Attribute chunk matched. Evaluating children of key: \"%s\".", key);
+
+			return oidc_authz_match_claim(r, spec_c, json_object_get(claims, key));
 		}
 
 		iter = json_object_iter_next((json_t *) claims, iter);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -422,6 +422,7 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_LOGIN_HINT            "login_hint"
 #define OIDC_PROTO_ID_TOKEN_HINT         "id_token_hint"
 #define OIDC_PROTO_REQUEST_URI           "request_uri"
+#define OIDC_PROTO_REQUEST_OBJECT        "request"
 #define OIDC_PROTO_SESSION_STATE         "session_state"
 #define OIDC_PROTO_ACTIVE                "active"
 

--- a/src/proto.c
+++ b/src/proto.c
@@ -455,7 +455,7 @@ char *oidc_proto_create_request_param(request_rec *r,
 
 	/* concatenate parameter with value */
 	char* request_param = NULL;
-	if (value != NULL && value != FALSE) {
+	if (value != NULL) {
 		request_param = apr_psprintf(r->pool, "%s=%s", parameter, value);
 	}
 

--- a/src/proto.c
+++ b/src/proto.c
@@ -456,7 +456,7 @@ char *oidc_proto_create_request_param(request_rec *r,
 	/* concatenate parameter with value */
 	char* request_param = NULL;
 	if (value != NULL) {
-		request_param = apr_psprintf(r->pool, "%s=%s", parameter, value);
+		request_param = apr_psprintf(r->pool, "%s=%s", parameter, oidc_util_escape_string(r, value));
 	}
 
 	return request_param;
@@ -575,7 +575,7 @@ int oidc_proto_authorization_request(request_rec *r,
 		if (request_param != NULL)
 			authorization_request = apr_psprintf(r->pool, "%s&%s",
 					authorization_request,
-					oidc_util_escape_string(r, request_param));
+					request_param);
 	}
 
 	/* cleanup */

--- a/src/proto.c
+++ b/src/proto.c
@@ -203,31 +203,16 @@ apr_byte_t oidc_proto_get_encryption_jwk_by_type(request_rec *r, oidc_cfg *cfg,
 }
 
 /*
- * generate a request object and pass it by reference in the authorization request
+ * generate a request object
  */
-char *oidc_proto_create_request_uri(request_rec *r,
-		struct oidc_provider_t *provider, const char *redirect_uri,
+char *oidc_proto_create_request_object(request_rec *r,
+		struct oidc_provider_t *provider, json_t * request_object_config,
 		const char *authorization_request) {
 
 	oidc_debug(r, "enter");
 
 	oidc_cfg *cfg = ap_get_module_config(r->server->module_config,
 			&auth_openidc_module);
-
-	/* parse the request object configuration from a string in to a JSON structure */
-	json_t *request_object_config = NULL;
-	if (oidc_util_decode_json_object(r, provider->request_object,
-			&request_object_config) == FALSE)
-		return FALSE;
-
-	/* see if we need to override the resolver URL, mostly for test purposes */
-	char *resolver_url = NULL;
-	if (json_object_get(request_object_config, "url") != NULL)
-		resolver_url = apr_pstrdup(r->pool,
-				json_string_value(
-						json_object_get(request_object_config, "url")));
-	else
-		resolver_url = apr_pstrdup(r->pool, redirect_uri);
 
 	/* create the request object value */
 	oidc_jwt_t *request_object = oidc_jwt_new(r->pool, TRUE, TRUE);
@@ -383,6 +368,31 @@ char *oidc_proto_create_request_uri(request_rec *r,
 	oidc_debug(r, "serialized request object = \"%s\"",
 			serialized_request_object);
 
+	return serialized_request_object;
+}
+
+/*
+ * generate a request object and pass it by reference in the authorization request
+ */
+char *oidc_proto_create_request_uri(request_rec *r,
+		struct oidc_provider_t *provider, json_t * request_object_config, const char *redirect_uri,
+		const char *authorization_request) {
+
+	oidc_debug(r, "enter");
+
+
+	/* see if we need to override the resolver URL, mostly for test purposes */
+	char *resolver_url = NULL;
+	if (json_object_get(request_object_config, "url") != NULL)
+		resolver_url = apr_pstrdup(r->pool,
+				json_string_value(
+						json_object_get(request_object_config, "url")));
+	else
+		resolver_url = apr_pstrdup(r->pool, redirect_uri);
+
+
+	char *serialized_request_object = oidc_proto_create_request_object(r, provider, request_object_config, authorization_request);
+
 	/* generate a temporary reference, store the request object in the cache and generate a Request URI that references it */
 	char *request_uri = NULL;
 	if (serialized_request_object != NULL) {
@@ -397,6 +407,59 @@ char *oidc_proto_create_request_uri(request_rec *r,
 	}
 
 	return request_uri;
+}
+
+/*
+ * Generic function to generate request/request_object parameter with value
+ */
+char *oidc_proto_create_request_param(request_rec *r,
+		struct oidc_provider_t *provider, const char *redirect_uri,
+		const char *authorization_request) {
+
+	/* parse the request object configuration from a string in to a JSON structure */
+	json_t *request_object_config = NULL;
+	if (oidc_util_decode_json_object(r, provider->request_object,
+			&request_object_config) == FALSE)
+		return FALSE;
+
+	/* request_uri is used as default parameter for sending Request Object */
+	char* parameter = OIDC_PROTO_REQUEST_URI;
+
+	/* get request_object_type parameter from config */
+	json_t *request_object_type = json_object_get(request_object_config, "request_object_type");
+	if (request_object_type != NULL) {
+		const char* request_object_type_str = json_string_value(request_object_type);
+		if (request_object_type_str == NULL) {
+			oidc_error(r, "Value of request_object_type in request_object config is not a string");
+			return FALSE;
+		}
+
+		/* ensure parameter variable to have a valid value */
+		if (strcmp(request_object_type_str, OIDC_PROTO_REQUEST_OBJECT) == 0) {
+			parameter = OIDC_PROTO_REQUEST_OBJECT;
+		} else if (strcmp(request_object_type_str, OIDC_PROTO_REQUEST_URI) != 0) {
+			oidc_error(r, "Bad request_object_type in config: %s", request_object_type_str);
+			return FALSE;
+		}
+	}
+
+	/* create request value */
+	char * value = NULL;
+	if (strcmp(parameter, OIDC_PROTO_REQUEST_URI) == 0) {
+		/* parameter is "request_uri" */
+		value = oidc_proto_create_request_uri(r, provider, request_object_config, redirect_uri, authorization_request);
+	} else {
+		/* parameter is "request" */
+		value = oidc_proto_create_request_object(r, provider, request_object_config, authorization_request);
+	}
+
+	/* concatenate parameter with value */
+	char* request_param = NULL;
+	if (value != NULL && value != FALSE) {
+		request_param = apr_psprintf(r->pool, "%s=%s", parameter, value);
+	}
+
+	return request_param;
 }
 
 /*
@@ -506,13 +569,13 @@ int oidc_proto_authorization_request(request_rec *r,
 	}
 
 	if (provider->request_object != NULL) {
-		/* add a request uri */
-		char *request_uri = oidc_proto_create_request_uri(r, provider,
+		/* add request parameter (request or request_uri) */
+		char *request_param = oidc_proto_create_request_param(r, provider,
 				redirect_uri, authorization_request);
-		if (request_uri != NULL)
-			authorization_request = apr_psprintf(r->pool, "%s&%s=%s",
-					authorization_request, OIDC_PROTO_REQUEST_URI,
-					oidc_util_escape_string(r, request_uri));
+		if (request_param != NULL)
+			authorization_request = apr_psprintf(r->pool, "%s&%s",
+					authorization_request,
+					oidc_util_escape_string(r, request_param));
 	}
 
 	/* cleanup */


### PR DESCRIPTION
OpenID Connect specification allows two different parameters to send Authorization Request.
This modification makes it configurible by introducing a new option in request_object or OIDCRequestObject config.