### PR TITLE
Set KID of private key

### DIFF
--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -482,7 +482,7 @@
 # keys that can be used to decrypt content sent to us by the OP.
 # These keys must correspond to the public keys defined in OIDCPublicKeyFiles.
 # When not defined no decryption will be possible.
-#OIDCPrivateKeyFiles [<filename>+]
+#OIDCPrivateKeyFiles ([<kid>#]<filename>)+
 
 # (Optional)
 # Define the Client JWKs URL (e.g. https://localhost/protected/?jwks=rsa)") that will be

--- a/src/config.c
+++ b/src/config.c
@@ -581,9 +581,16 @@ static const char *oidc_set_private_key_files_enc(cmd_parms *cmd, void *dummy,
 	oidc_jwk_t *jwk = NULL;
 	oidc_jose_error_t err;
 
-	if (oidc_jwk_parse_rsa_private_key(cmd->pool, arg, &jwk, &err) == FALSE) {
+	char *kid = NULL, *fname = NULL;
+	int fname_len;
+	const char *rv = oidc_parse_enc_kid_key_tuple(cmd->pool, arg, &kid, &fname,
+			&fname_len, FALSE);
+	if (rv != NULL)
+	return rv;
+
+	if (oidc_jwk_parse_rsa_private_key(cmd->pool, kid, fname, &jwk, &err) == FALSE) {
 		return apr_psprintf(cmd->pool,
-				"oidc_jwk_parse_rsa_private_key failed for \"%s\": %s", arg,
+				"oidc_jwk_parse_rsa_private_key failed for (kid=%s) \"%s\": %s", kid, fname,
 				oidc_jose_e2s(cmd->pool, err));
 	}
 

--- a/src/config.c
+++ b/src/config.c
@@ -586,7 +586,7 @@ static const char *oidc_set_private_key_files_enc(cmd_parms *cmd, void *dummy,
 	const char *rv = oidc_parse_enc_kid_key_tuple(cmd->pool, arg, &kid, &fname,
 			&fname_len, FALSE);
 	if (rv != NULL)
-	return rv;
+		return rv;
 
 	if (oidc_jwk_parse_rsa_private_key(cmd->pool, kid, fname, &jwk, &err) == FALSE) {
 		return apr_psprintf(cmd->pool,

--- a/src/jose.c
+++ b/src/jose.c
@@ -1235,9 +1235,9 @@ static apr_byte_t oidc_jwk_parse_rsa_x5c(apr_pool_t *pool, json_t *json,
 /*
  * parse an X.509 PEM formatted certificate file with an RSA public key to a JWK struct
  */
-apr_byte_t oidc_jwk_parse_rsa_private_key(apr_pool_t *pool,
+apr_byte_t oidc_jwk_parse_rsa_private_key(apr_pool_t *pool,  const char *kid,
 		const char *filename, oidc_jwk_t **jwk, oidc_jose_error_t *err) {
-	return oidc_jwk_parse_rsa_key(pool, TRUE, NULL, filename, jwk, err);
+	return oidc_jwk_parse_rsa_key(pool, TRUE, kid, filename, jwk, err);
 }
 
 /*

--- a/src/jose.h
+++ b/src/jose.h
@@ -168,7 +168,7 @@ oidc_jwk_t *oidc_jwk_create_symmetric_key(apr_pool_t *pool, const char *kid,
 apr_byte_t oidc_jwk_parse_rsa_public_key(apr_pool_t *pool, const char *kid,
 		const char *filename, oidc_jwk_t **jwk, oidc_jose_error_t *err);
 /* parse an X.509 PEM formatted RSA private key file to a JWK */
-apr_byte_t oidc_jwk_parse_rsa_private_key(apr_pool_t *pool,
+apr_byte_t oidc_jwk_parse_rsa_private_key(apr_pool_t *pool, const char *kid,
 		const char *filename, oidc_jwk_t **jwk, oidc_jose_error_t *err);
 
 /*


### PR DESCRIPTION
Allow static configuration of RSA private keys using OIDCPrivateKeyFiles directive in a similar way as it can be configured for OIDCPublicKeyFiles