### PR TITLE
Add support for extensions in the access_token

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1092,6 +1092,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->info_hook_data = NULL;
 	c->black_listed_claims = NULL;
 	c->white_listed_claims = NULL;
+	c->extensions = NULL;
 
 	return c;
 }
@@ -1502,6 +1503,9 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			add->white_listed_claims != NULL ?
 					add->white_listed_claims : base->white_listed_claims;
 
+	c->extensions =
+			add->extensions != NULL ?
+					add->extensions : base->extensions;
 	return c;
 }
 
@@ -2687,6 +2691,11 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, provider.auth_request_method),
 				RSRC_CONF,
 				"HTTP method used to send the authentication request to the provider (GET or POST)."),
+		AP_INIT_TAKE1("OIDCTokenExtensions",
+				oidc_set_string_slot,
+				(void*)APR_OFFSETOF(oidc_cfg, extensions),
+				RSRC_CONF,
+				"List of extension elements to parse out of the token response."),
 		AP_INIT_ITERATE(OIDCInfoHook,
 				oidc_set_info_hook_data,
 				(void *)APR_OFFSETOF(oidc_cfg, info_hook_data),

--- a/src/mod_auth_openidc.c
+++ b/src/mod_auth_openidc.c
@@ -1087,11 +1087,12 @@ static apr_byte_t oidc_refresh_access_token(request_rec *r, oidc_cfg *c,
 	char *s_token_type = NULL;
 	char *s_access_token = NULL;
 	char *s_refresh_token = NULL;
+	char *s_extensions = NULL;
 
 	/* refresh the tokens by calling the token endpoint */
 	if (oidc_proto_refresh_request(r, c, provider, refresh_token, &s_id_token,
 			&s_access_token, &s_token_type, &expires_in,
-			&s_refresh_token) == FALSE) {
+			&s_refresh_token, &s_extensions) == FALSE) {
 		oidc_error(r, "access_token could not be refreshed");
 		return FALSE;
 	}
@@ -1305,6 +1306,15 @@ static apr_byte_t oidc_session_pass_tokens_and_save(request_rec *r,
 		oidc_util_set_app_info(r, OIDC_APP_INFO_ACCESS_TOKEN_EXP,
 				access_token_expires,
 				OIDC_DEFAULT_HEADER_PREFIX, pass_headers, pass_envvars);
+	}
+	if (cfg->extensions != NULL) {
+		const char *extensions = NULL;
+		/* get the serialized extensions from the session */
+		oidc_session_get(r, session, OIDC_PROTO_EXTENSIONS, &extensions);
+		/* pass it to the app in a header or environment variable */
+		oidc_util_set_app_info(r, "extensions", extensions,
+				OIDC_DEFAULT_HEADER_PREFIX,
+				pass_headers, pass_envvars);
 	}
 
 	/*
@@ -1581,7 +1591,7 @@ static apr_byte_t oidc_save_in_session(request_rec *r, oidc_cfg *c,
 		const char *remoteUser, const char *id_token, oidc_jwt_t *id_token_jwt,
 		const char *claims, const char *access_token, const int expires_in,
 		const char *refresh_token, const char *session_state, const char *state,
-		const char *original_url) {
+		const char *extensions, const char *original_url) {
 
 	/* store the user in the session */
 	session->remote_user = remoteUser;
@@ -1631,6 +1641,10 @@ static apr_byte_t oidc_save_in_session(request_rec *r, oidc_cfg *c,
 
 	/* store claims resolved from userinfo endpoint */
 	oidc_store_userinfo_claims(r, session, provider, claims);
+
+	if (extensions != NULL) {
+		oidc_session_set(r, session, OIDC_PROTO_EXTENSIONS, extensions);
+	}
 
 	/* see if we have an access_token */
 	if (access_token != NULL) {
@@ -1867,7 +1881,8 @@ static int oidc_handle_authorization_response(request_rec *r, oidc_cfg *c,
 				apr_table_get(params, OIDC_PROTO_ACCESS_TOKEN), expires_in,
 				apr_table_get(params, OIDC_PROTO_REFRESH_TOKEN),
 				apr_table_get(params, OIDC_PROTO_SESSION_STATE),
-				apr_table_get(params, OIDC_PROTO_STATE), original_url) == FALSE)
+				apr_table_get(params, OIDC_PROTO_STATE),
+				apr_table_get(params, OIDC_PROTO_EXTENSIONS), original_url) == FALSE)
 			return HTTP_INTERNAL_SERVER_ERROR;
 
 	} else {

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -378,6 +378,7 @@ typedef struct oidc_cfg {
 	char *outgoing_proxy;
 
 	char *crypto_passphrase;
+	char *extensions;
 
 	int provider_metadata_refresh_interval;
 
@@ -446,6 +447,7 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_REQUEST_OBJECT        "request"
 #define OIDC_PROTO_SESSION_STATE         "session_state"
 #define OIDC_PROTO_ACTIVE                "active"
+#define OIDC_PROTO_EXTENSIONS            "extensions"
 
 #define OIDC_PROTO_RESPONSE_TYPE_CODE               "code"
 #define OIDC_PROTO_RESPONSE_TYPE_IDTOKEN            "id_token"
@@ -580,7 +582,7 @@ char *oidc_proto_peek_jwt_header(request_rec *r, const char *jwt, char **alg);
 int oidc_proto_authorization_request(request_rec *r, struct oidc_provider_t *provider, const char *login_hint, const char *redirect_uri, const char *state, oidc_proto_state_t *proto_state, const char *id_token_hint, const char *code_challenge, const char *auth_request_params, const char *path_scope);
 apr_byte_t oidc_proto_is_post_authorization_response(request_rec *r, oidc_cfg *cfg);
 apr_byte_t oidc_proto_is_redirect_authorization_response(request_rec *r, oidc_cfg *cfg);
-apr_byte_t oidc_proto_refresh_request(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *rtoken, char **id_token, char **access_token, char **token_type, int *expires_in, char **refresh_token);
+apr_byte_t oidc_proto_refresh_request(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *rtoken, char **id_token, char **access_token, char **token_type, int *expires_in, char **refresh_token, char **extensions);
 apr_byte_t oidc_proto_resolve_userinfo(request_rec *r, oidc_cfg *cfg, oidc_provider_t *provider, const char *id_token_sub, const char *access_token, char **response);
 apr_byte_t oidc_proto_account_based_discovery(request_rec *r, oidc_cfg *cfg, const char *acct, char **issuer);
 apr_byte_t oidc_proto_url_based_discovery(request_rec *r, oidc_cfg *cfg, const char *url, char **issuer);


### PR DESCRIPTION
Hi,

For our project we have some extensions in  the access tokens that we need to be able to extract and process at the application level.

This patch extracts the json data which match the names listed in the OIDCTokenExtensions  configuration parameter and stores the string serialization of them into the session and passes that into the application environment.

- OIDCTokenExtensions: a list of json elements to parse from
  the access token response and include in the session state.
- export extensions to the app environment as OIDC_extensions