### PR TITLE
Add regex substitution for *RemoteUserClaims

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,7 +12,8 @@ SRC=src/mod_auth_openidc.c \
 	src/session.c \
 	src/metadata.c \
 	src/jose.c \
-	src/parse.c
+	src/parse.c \
+	src/pcre_subst.c \
 
 ifeq (@HAVE_LIBHIREDIS@, 1)
 SRC += \
@@ -31,7 +32,8 @@ HDRS = \
 	src/mod_auth_openidc.h \
 	src/jose.h \
 	src/parse.h \
-	src/cache/cache.h
+	src/cache/cache.h \
+	src/pcre_subst.h \
 
 # Files to include when making a .tar.gz-file for distribution
 DISTFILES=$(SRC) \

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -365,6 +365,11 @@
 # An optional regular expression can be added as a 2nd parameter that will be applied to the
 # claim value from the 1st parameter and the first match returned from that expression will
 # be set as the REMOTE_USER. E.g. to strip a domain from an e-mail style address you'd use ^(.*)@
+#
+# An optional 3rd parameter can be added that would contain string with number backrefrences.
+# Backrefrences must be in the form $1, $2.. etc.
+# E.g. to extract username in the form DOMAIN\userid from e-mail style address you may use
+#   ^(.*)@([^.]+)\..+$ $2\\$1
 #OIDCOAuthRemoteUserClaim <claim-name> [<regular-expression>]
 
 # Define the way(s) in which bearer OAuth 2.0 access tokens can be passed to this Resource Server.
@@ -616,6 +621,11 @@
 # An optional regular expression can be added as a 2nd parameter that will be applied to the
 # resulting value from the 1st parameter and the first match returned from that expression will
 # be set as the REMOTE_USER. E.g. to strip a domain from an e-mail style address you'd use ^(.*)@
+#
+# An optional 3rd parameter can be added that would contain string with number backrefrences.
+# Backrefrences must be in the form $1, $2.. etc.
+# E.g. to extract username in the form DOMAIN\userid from e-mail style address you may use
+#  ^(.*)@([^.]+)\..+$ $2\\$1
 #OIDCRemoteUserClaim <claim-name>[@] [<regular-expression>]
 
 # Define the way(s) in which the id_token contents are passed to the application according to OIDCPassClaimsAs.

--- a/src/config.c
+++ b/src/config.c
@@ -83,8 +83,12 @@
 #define OIDC_DEFAULT_CLAIM_PREFIX "OIDC_CLAIM_"
 /* default name for the claim that will contain the REMOTE_USER value for OpenID Connect protected paths */
 #define OIDC_DEFAULT_CLAIM_REMOTE_USER "sub@"
+/* default replace str for regex, $1 represent the first match group*/
+#define OIDC_DEFAULT_CLAIM_REMOTE_USER_REPLACE "$1"
 /* default name for the claim that will contain the REMOTE_USER value for OAuth 2.0 protected paths */
 #define OIDC_DEFAULT_OAUTH_CLAIM_REMOTE_USER "sub"
+/* default replace str for regex, $1 represent the first match group*/
+#define OIDC_DEFAULT_OAUTH_CLAIM_REMOTE_USER_REPLACE "$1"
 /* default name of the session cookie */
 #define OIDC_DEFAULT_COOKIE "mod_auth_openidc_session"
 /* default for the HTTP header name in which the remote user name is passed */
@@ -803,7 +807,7 @@ static const char *oidc_set_preserve_post(cmd_parms *cmd, void *m,
  * set the remote user name claims, optionally plus the regular expression applied to it
  */
 static const char *oidc_set_remote_user_claim(cmd_parms *cmd, void *struct_ptr,
-		const char *v1, const char *v2) {
+		const char *v1, const char *v2, const char *v3) {
 	oidc_cfg *cfg = (oidc_cfg *) ap_get_module_config(
 			cmd->server->module_config, &auth_openidc_module);
 
@@ -814,6 +818,8 @@ static const char *oidc_set_remote_user_claim(cmd_parms *cmd, void *struct_ptr,
 	remote_user_claim->claim_name = v1;
 	if (v2)
 		remote_user_claim->reg_exp = v2;
+    if (v3)
+        remote_user_claim->replace = v3;
 
 	return NULL;
 }
@@ -1037,6 +1043,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->oauth.remote_user_claim.claim_name =
 			OIDC_DEFAULT_OAUTH_CLAIM_REMOTE_USER;
 	c->oauth.remote_user_claim.reg_exp = NULL;
+    c->oauth.remote_user_claim.replace = OIDC_DEFAULT_OAUTH_CLAIM_REMOTE_USER_REPLACE;
 
 	c->oauth.verify_jwks_uri = NULL;
 	c->oauth.verify_public_keys = NULL;
@@ -1073,6 +1080,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->claim_prefix = NULL;
 	c->remote_user_claim.claim_name = OIDC_DEFAULT_CLAIM_REMOTE_USER;
 	c->remote_user_claim.reg_exp = NULL;
+    c->remote_user_claim.replace = OIDC_DEFAULT_CLAIM_REMOTE_USER_REPLACE;
 	c->pass_idtoken_as = OIDC_PASS_IDTOKEN_AS_CLAIMS;
 	c->cookie_http_only = OIDC_DEFAULT_COOKIE_HTTPONLY;
 	c->cookie_same_site = OIDC_DEFAULT_COOKIE_SAME_SITE;
@@ -1342,6 +1350,11 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			add->oauth.remote_user_claim.reg_exp != NULL ?
 					add->oauth.remote_user_claim.reg_exp :
 					base->oauth.remote_user_claim.reg_exp;
+    c->oauth.remote_user_claim.replace =
+            apr_strnatcmp(add->oauth.remote_user_claim.replace,
+                          OIDC_DEFAULT_OAUTH_CLAIM_REMOTE_USER_REPLACE) != 0 ?
+            add->oauth.remote_user_claim.replace :
+            base->oauth.remote_user_claim.replace;
 
 	c->oauth.verify_jwks_uri =
 			add->oauth.verify_jwks_uri != NULL ?
@@ -1448,6 +1461,11 @@ void *oidc_merge_server_config(apr_pool_t *pool, void *BASE, void *ADD) {
 			add->remote_user_claim.reg_exp != NULL ?
 					add->remote_user_claim.reg_exp :
 					base->remote_user_claim.reg_exp;
+    c->remote_user_claim.replace =
+            apr_strnatcmp(add->remote_user_claim.replace,
+                          OIDC_DEFAULT_CLAIM_REMOTE_USER_REPLACE) != 0 ?
+            add->remote_user_claim.replace :
+            base->remote_user_claim.replace;
 	c->pass_idtoken_as =
 			add->pass_idtoken_as != OIDC_PASS_IDTOKEN_AS_CLAIMS ?
 					add->pass_idtoken_as : base->pass_idtoken_as;
@@ -2420,7 +2438,7 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, claim_prefix),
 				RSRC_CONF,
 				"The prefix to use when setting claims in the HTTP headers."),
-		AP_INIT_TAKE12(OIDCRemoteUserClaim,
+		AP_INIT_TAKE123(OIDCRemoteUserClaim,
 				oidc_set_remote_user_claim,
 				(void*)APR_OFFSETOF(oidc_cfg, remote_user_claim),
 				RSRC_CONF,
@@ -2489,7 +2507,7 @@ const command_rec oidc_config_cmds[] = {
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.ssl_validate_server),
 				RSRC_CONF,
 				"Require validation of the OAuth 2.0 AS Validation Endpoint SSL server certificate for successful authentication (On or Off)"),
-		AP_INIT_TAKE12(OIDCOAuthRemoteUserClaim,
+		AP_INIT_TAKE123(OIDCOAuthRemoteUserClaim,
 				oidc_set_remote_user_claim,
 				(void*)APR_OFFSETOF(oidc_cfg, oauth.remote_user_claim),
 				RSRC_CONF,

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -403,7 +403,8 @@ apr_byte_t oidc_post_preserve_javascript(request_rec *r, const char *location, c
 void oidc_scrub_headers(request_rec *r);
 void oidc_strip_cookies(request_rec *r);
 int oidc_content_handler(request_rec *r);
-apr_byte_t oidc_get_remote_user(request_rec *r, const char *claim_name, const char *reg_exp, json_t *json, char **request_user);
+apr_byte_t oidc_get_remote_user(request_rec *r, const char *claim_name, const char *replace, const char *reg_exp,
+                                json_t *json, char **request_user);
 
 #define OIDC_REDIRECT_URI_REQUEST_INFO             "info"
 #define OIDC_REDIRECT_URI_REQUEST_LOGOUT           "logout"
@@ -707,6 +708,7 @@ apr_byte_t oidc_json_object_get_int(apr_pool_t *pool, json_t *json, const char *
 char *oidc_util_html_escape(apr_pool_t *pool, const char *input);
 void oidc_util_table_add_query_encoded_params(apr_pool_t *pool, apr_table_t *table, const char *params);
 apr_hash_t * oidc_util_merge_key_sets(apr_pool_t *pool, apr_hash_t *k1, apr_hash_t *k2);
+apr_byte_t oidc_util_regexp_substitute(apr_pool_t *pool, const char *input, const char *regexp, const char *replace, char **output, char **error_str);
 apr_byte_t oidc_util_regexp_first_match(apr_pool_t *pool, const char *input, const char *regexp, char **output, char **error_str);
 apr_byte_t oidc_util_json_merge(request_rec *r, json_t *src, json_t *dst);
 int oidc_util_cookie_domain_valid(const char *hostname, char *cookie_domain);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -282,6 +282,7 @@ typedef struct oidc_provider_t {
 typedef struct oidc_remote_user_claim_t {
 	const char *claim_name;
 	const char *reg_exp;
+	const char *replace;
 } oidc_remote_user_claim_t;
 
 typedef struct oidc_oauth_t {

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -558,7 +558,7 @@ static apr_byte_t oidc_oauth_set_request_user(request_rec *r, oidc_cfg *c,
 	char *remote_user = NULL;
 
 	if (oidc_get_remote_user(r, c->oauth.remote_user_claim.claim_name,
-			c->oauth.remote_user_claim.reg_exp, token, &remote_user) == FALSE) {
+			c->oauth.remote_user_claim.reg_exp, c->oauth.remote_user_claim.replace, token, &remote_user) == FALSE) {
 		oidc_error(r,
 				"" OIDCOAuthRemoteUserClaim " is set to \"%s\", but could not set the remote user based the available claims for the user",
 				c->oauth.remote_user_claim.claim_name);
@@ -566,14 +566,12 @@ static apr_byte_t oidc_oauth_set_request_user(request_rec *r, oidc_cfg *c,
 	}
 
 	r->user = remote_user;
-
-	oidc_debug(r, "set user to \"%s\" based on claim: \"%s\"%s", r->user,
-			c->oauth.remote_user_claim.claim_name,
-			c->oauth.remote_user_claim.reg_exp ?
-					apr_psprintf(r->pool, " and expression: \"%s\"",
-							c->oauth.remote_user_claim.reg_exp) :
-							"");
-
+    oidc_debug(r, "set user to \"%s\" based on claim: \"%s\"%s", r->user,
+               c->oauth.remote_user_claim.claim_name,
+               c->oauth.remote_user_claim.reg_exp ?
+               apr_psprintf(r->pool, " and expression: \"%s\" and replace string: \"%s\"",
+                            c->oauth.remote_user_claim.reg_exp, c->oauth.remote_user_claim.replace) :
+               "");
 	return TRUE;
 }
 

--- a/src/pcre_subst.c
+++ b/src/pcre_subst.c
@@ -1,0 +1,191 @@
+/*************************************************
+*      PCRE string replacement                   *
+*************************************************/
+
+/*
+PCRE is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+pcre_subst is a wrapper around pcre_exec designed to make it easier to
+perform PERL style replacements with PCRE.
+
+Written by: Bert Driehuis <driehuis@playbeing.org>
+
+           Copyright (c) 2000 Bert Driehuis
+
+-----------------------------------------------------------------------------
+Permission is granted to anyone to use this software for any purpose on any
+computer system, and to redistribute it freely, subject to the following
+restrictions:
+
+1. This software is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+2. The origin of this software must not be misrepresented, either by
+   explicit claim or by omission.
+
+3. Altered versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+4. If PCRE is embedded in any software that is released under the GNU
+   General Purpose Licence (GPL), then the terms of that licence shall
+   supersede any condition above with which it is incompatible.
+*/
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+#include <pcre.h>
+#include "pcre_subst.h"
+
+#define MAXCAPTURE	50
+
+#ifdef DEBUG_PCRE_SUBST
+static void
+dumpstr(const char *str, int len, int start, int end)
+{
+	int i;
+	for (i = 0; i < strlen(str); i++) {
+		if (i >= start && i < end)
+			putchar(str[i]);
+		else
+			putchar('-');
+	}
+	putchar('\n');
+}
+
+static void
+dumpmatch(const char *str, int len, const char *rep, int nmat, const int *ovec)
+{
+	int i;
+	printf("%s	Input\n", str);
+	printf("nmat=%d", nmat);
+	for (i = 0; i < nmat * 2; i++)
+		printf(" %d", ovec[i]);
+	printf("\n");
+	for (i = 0; i < nmat * 2; i += 2)
+		dumpstr(str, len, ovec[i], ovec[i+1]);
+	printf("\n");
+}
+#endif
+
+static int
+findreplen(const char *rep, int nmat, const int *replen)
+{
+	int len = 0;
+	int val;
+	char *cp = (char *)rep;
+	while(*cp) {
+		if (*cp == '$' && isdigit(cp[1])) {
+			val = strtoul(&cp[1], &cp, 10);
+			if (val && val <= nmat + 1)
+				len += replen[val -1];
+			else
+				fprintf(stderr, "repl %d out of range\n", val);
+		} else {
+			cp++;
+			len++;
+		}
+	}
+	return len;
+}
+
+static void
+doreplace(char *out, const char *rep, int nmat, int *replen, const char **repstr)
+{
+	int val;
+	char *cp = (char *)rep;
+	while(*cp) {
+		if (*cp == '$' && isdigit(cp[1])) {
+			val = strtoul(&cp[1], &cp, 10);
+			if (val && val <= nmat + 1) {
+				strncpy(out, repstr[val - 1], replen[val - 1]);
+				out += replen[val -1];
+			}
+		} else {
+			*out++ = *cp++;
+		}
+	}
+}
+
+static char *
+edit(const char *str, int len, const char *rep, int nmat, const int *ovec)
+{
+	int i, slen, rlen;
+	const int *mvec = ovec;
+	char *res, *cp;
+	int replen[MAXCAPTURE];
+	const char *repstr[MAXCAPTURE];
+	nmat--;
+	ovec += 2;
+	for (i = 0; i < nmat; i++) {
+		replen[i] = ovec[i * 2 + 1] - ovec[i * 2];
+		repstr[i] = &str[ovec[i * 2]];
+#ifdef DEBUG_PCRE_SUBST
+		printf(">>>%d %d %.*s\n", i, replen[i], replen[i], repstr[i]);
+#endif
+	}
+	slen = len;
+	len -= mvec[1] - mvec[0];
+	len += rlen = findreplen(rep, nmat, replen);
+#ifdef DEBUG_PCRE_SUBST
+	printf("resulting length %d (srclen=%d)\n", len, slen);
+#endif
+	cp = res = pcre_malloc(len + 1);
+	if (mvec[0] > 0) {
+		strncpy(cp, str, mvec[0]);
+		cp += mvec[0];
+	}
+	doreplace(cp, rep, nmat, replen, repstr);
+	cp += rlen;
+	if (mvec[1] < slen)
+		strcpy(cp, &str[mvec[1]]);
+	res[len] = 0;
+	return res;
+}
+
+char *
+pcre_subst(const pcre *ppat, const pcre_extra *extra, const char *str, int len,
+			int offset, int options, const char *rep)
+{
+	int nmat;
+	int ovec[MAXCAPTURE * 3];
+	nmat = pcre_exec(ppat, extra, str, len, offset, options,
+		ovec, sizeof(ovec));
+#ifdef DEBUG_PCRE_SUBST
+	dumpmatch(str, len, rep, nmat, ovec);
+#endif
+	if (nmat <= 0)
+		return NULL;
+	return(edit(str, len, rep, nmat, ovec));
+}
+
+#ifdef DEBUG_BUILD
+int
+main()
+{
+	char *pat = "quick\\s(\\w+)\\s(fox)";
+	char *rep = "$1ish $2";
+	char *str = "The quick brown foxy";
+	char *newstr;
+	const char *err;
+	int erroffset;
+	pcre_extra *extra;
+	pcre *ppat = pcre_compile(pat, 0, &err, &erroffset, NULL);
+	if (ppat == NULL) {
+		fprintf(stderr, "%s at %d\n", err, erroffset);
+		exit(1);
+	}
+	extra = pcre_study(ppat, 0, &err);
+	if (err != NULL)
+		fprintf(stderr, "Study %s failed: %s\n", pat, err);
+	newstr = pcre_subst(ppat, extra, str, strlen(str), 0, 0, rep);
+	if (newstr) {
+		printf("Newstr\t%s\n", newstr);
+		pcre_free(newstr);
+	} else {
+		printf("No match\n");
+	}
+	return 0;
+}
+#endif

--- a/src/pcre_subst.h
+++ b/src/pcre_subst.h
@@ -1,0 +1,35 @@
+/*************************************************
+*      PCRE string replacement                   *
+*************************************************/
+
+/*
+PCRE is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+pcre_subst is a wrapper around pcre_exec designed to make it easier to
+perform PERL style replacements with PCRE.
+
+Written by: Bert Driehuis <driehuis@playbeing.org>
+
+           Copyright (c) 2000 Bert Driehuis
+
+-----------------------------------------------------------------------------
+Permission is granted to anyone to use this software for any purpose on any
+computer system, and to redistribute it freely, subject to the following
+restrictions:
+
+1. This software is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+2. The origin of this software must not be misrepresented, either by
+   explicit claim or by omission.
+
+3. Altered versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+4. If PCRE is embedded in any software that is released under the GNU
+   General Purpose Licence (GPL), then the terms of that licence shall
+   supersede any condition above with which it is incompatible.
+*/
+
+char *pcre_subst(const pcre *, const pcre_extra *, const char *, int, int, int, const char *);

--- a/src/util.c
+++ b/src/util.c
@@ -61,9 +61,9 @@
 #include <curl/curl.h>
 
 #include "mod_auth_openidc.h"
-#include "pcre_subst.h"
 
 #include <pcre.h>
+#include "pcre_subst.h"
 
 /* hrm, should we get rid of this by adding parameters to the (3) functions? */
 extern module AP_MODULE_DECLARE_DATA auth_openidc_module;


### PR DESCRIPTION
Hello, 

I wanted to use extracted RemoteUserClaims using regex and also allow modification to it. I enhanced it to allow group substitution. The PCRE based substitution is from the [pcre_example](ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/Contrib/pcre_subst.tar.gz)

```
# OIDCOAuthRemoteUserClaim <claim-name> [<regular-expression>] [<substitution-string>]
# sub: user@domain.com 
# remote_user: domain_user
OIDCOAuthRemoteUserClaim  sub  ^(.*)@(.*)\.([^.]*)$  $2_$1
```
