### PR TITLE
Added client_secret_bearer functionality for token introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /discover
 /metadata
 /.settings
+.kdev4/
+*.kdev4

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -285,10 +285,10 @@
 # Used to authenticate the client to the introspection endpoint e.g. with a client_id/client_secret
 # when OIDCOAuthClientID and OIDCOAuthClientSecret have been set and "client_secret_basic" or "client_secret_post"
 # has been configured.
-# client_secret_bearer uses the inspected token itself for authorization on the inspection endpoint, as some OP do not accept Basic or post, only Bearer
+# client_bearer uses the inspected token itself for authorization on the inspection endpoint, as some OP do not accept Basic or post, only Bearer
 # When "private_key_jwt" is used, OIDCPrivateKeyFiles and OIDCPublicKeyFiles must have been set.
 # When not defined "client_secret_basic" is used.
-#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_secret_bearer | client_secret_jwt | private_key_jwt]
+#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_bearer | client_secret_jwt | private_key_jwt]
 
 # Filename that contains the PEM-formatted client certificate used to authenticate the
 # caller in token introspection calls to the OAuth 2.0 Authorization server.

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -285,10 +285,15 @@
 # Used to authenticate the client to the introspection endpoint e.g. with a client_id/client_secret
 # when OIDCOAuthClientID and OIDCOAuthClientSecret have been set and "client_secret_basic" or "client_secret_post"
 # has been configured.
-# client_bearer uses the inspected token itself for authorization on the inspection endpoint, as some OP do not accept Basic or post, only Bearer
 # When "private_key_jwt" is used, OIDCPrivateKeyFiles and OIDCPublicKeyFiles must have been set.
 # When not defined "client_secret_basic" is used.
-#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_bearer | client_secret_jwt | private_key_jwt]
+#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_secret_jwt | private_key_jwt]
+
+# Some OP do not accept basic or post, only bearer tokens in the Authorization header.
+# Specify here a static token to be used for authorizing the call to the introspection endpoint.
+# If empty, the introspected token will be used for authorization as well.
+# If unset, one of the methods specified by OIDCOAuthIntrospectionEndpointAuth will be used.
+#OIDCOAuthIntrospectionClientAuthBearerToken [ a-static-bearer-token | ]
 
 # Filename that contains the PEM-formatted client certificate used to authenticate the
 # caller in token introspection calls to the OAuth 2.0 Authorization server.

--- a/auth_openidc.conf
+++ b/auth_openidc.conf
@@ -285,9 +285,10 @@
 # Used to authenticate the client to the introspection endpoint e.g. with a client_id/client_secret
 # when OIDCOAuthClientID and OIDCOAuthClientSecret have been set and "client_secret_basic" or "client_secret_post"
 # has been configured.
+# client_secret_bearer uses the inspected token itself for authorization on the inspection endpoint, as some OP do not accept Basic or post, only Bearer
 # When "private_key_jwt" is used, OIDCPrivateKeyFiles and OIDCPublicKeyFiles must have been set.
 # When not defined "client_secret_basic" is used.
-#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_secret_jwt | private_key_jwt]
+#OIDCOAuthIntrospectionEndpointAuth [ client_secret_basic | client_secret_post | client_secret_bearer | client_secret_jwt | private_key_jwt]
 
 # Filename that contains the PEM-formatted client certificate used to authenticate the
 # caller in token introspection calls to the OAuth 2.0 Authorization server.

--- a/src/config.c
+++ b/src/config.c
@@ -1040,6 +1040,7 @@ void *oidc_create_server_config(apr_pool_t *pool, server_rec *svr) {
 	c->oauth.introspection_endpoint_url = NULL;
 	c->oauth.introspection_endpoint_method = OIDC_DEFAULT_OAUTH_ENDPOINT_METHOD;
 	c->oauth.introspection_endpoint_params = NULL;
+	c->oauth.introspection_endpoint_auth = NULL;
 	c->oauth.introspection_client_auth_bearer_token = NULL;
 	c->oauth.introspection_token_param_name =
 			OIDC_DEFAULT_OAUTH_TOKEN_PARAM_NAME;

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1272,13 +1272,13 @@ apr_byte_t oidc_metadata_client_parse(request_rec *r, oidc_cfg *cfg,
 		if ((apr_strnatcmp(token_endpoint_auth, OIDC_PROTO_CLIENT_SECRET_POST)
 				== 0)
 				|| (apr_strnatcmp(token_endpoint_auth,
-						OIDC_PROTO_CLIENT_SECRET_BASIC) == 0)
-                        || (apr_strnatcmp(token_endpoint_auth,
-								OIDC_PROTO_CLIENT_SECRET_BEARER) == 0)
-                                || (apr_strnatcmp(token_endpoint_auth,
-                                        OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
-                                        || (apr_strnatcmp(token_endpoint_auth,
-                                                OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
+				OIDC_PROTO_CLIENT_SECRET_BASIC) == 0)
+					|| (apr_strnatcmp(token_endpoint_auth,
+					OIDC_PROTO_CLIENT_BEARER) == 0)
+						|| (apr_strnatcmp(token_endpoint_auth,
+						OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
+							|| (apr_strnatcmp(token_endpoint_auth,
+							OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
 			provider->token_endpoint_auth = apr_pstrdup(r->pool,
 					token_endpoint_auth);
 		} else {

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1273,10 +1273,12 @@ apr_byte_t oidc_metadata_client_parse(request_rec *r, oidc_cfg *cfg,
 				== 0)
 				|| (apr_strnatcmp(token_endpoint_auth,
 						OIDC_PROTO_CLIENT_SECRET_BASIC) == 0)
-						|| (apr_strnatcmp(token_endpoint_auth,
-								OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
-								|| (apr_strnatcmp(token_endpoint_auth,
-										OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
+                        || (apr_strnatcmp(token_endpoint_auth,
+								OIDC_PROTO_CLIENT_SECRET_BEARER) == 0)
+                                || (apr_strnatcmp(token_endpoint_auth,
+                                        OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
+                                        || (apr_strnatcmp(token_endpoint_auth,
+                                                OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
 			provider->token_endpoint_auth = apr_pstrdup(r->pool,
 					token_endpoint_auth);
 		} else {

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -1272,13 +1272,11 @@ apr_byte_t oidc_metadata_client_parse(request_rec *r, oidc_cfg *cfg,
 		if ((apr_strnatcmp(token_endpoint_auth, OIDC_PROTO_CLIENT_SECRET_POST)
 				== 0)
 				|| (apr_strnatcmp(token_endpoint_auth,
-				OIDC_PROTO_CLIENT_SECRET_BASIC) == 0)
-					|| (apr_strnatcmp(token_endpoint_auth,
-					OIDC_PROTO_CLIENT_BEARER) == 0)
-						|| (apr_strnatcmp(token_endpoint_auth,
-						OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
-							|| (apr_strnatcmp(token_endpoint_auth,
-							OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
+								OIDC_PROTO_CLIENT_SECRET_BASIC) == 0)
+								|| (apr_strnatcmp(token_endpoint_auth,
+												OIDC_PROTO_CLIENT_SECRET_JWT) == 0)
+												|| (apr_strnatcmp(token_endpoint_auth,
+																OIDC_PROTO_PRIVATE_KEY_JWT) == 0)) {
 			provider->token_endpoint_auth = apr_pstrdup(r->pool,
 					token_endpoint_auth);
 		} else {

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -478,6 +478,7 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_CLIENT_ASSERTION_TYPE_JWT_BEARER "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 #define OIDC_PROTO_CLIENT_SECRET_BASIC "client_secret_basic"
+#define OIDC_PROTO_CLIENT_SECRET_BEARER   "client_secret_bearer"
 #define OIDC_PROTO_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_PROTO_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_PROTO_PRIVATE_KEY_JWT     "private_key_jwt"
@@ -580,7 +581,7 @@ void oidc_proto_state_set_prompt(oidc_proto_state_t *proto_state, const char *pr
 void oidc_proto_state_set_pkce_state(oidc_proto_state_t *proto_state, const char *pkce_state);
 void oidc_proto_state_set_timestamp_now(oidc_proto_state_t *proto_state);
 
-apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg, const char *token_endpoint_auth, const char *client_id, const char *client_secret, const char *audience, apr_table_t *params, char **basic_auth_str);
+apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg, const char *token_endpoint_auth, const char *client_id, const char *client_secret, const char *audience, apr_table_t *params, char **basic_auth_str, char **bearer_auth_str);
 
 char *oidc_proto_peek_jwt_header(request_rec *r, const char *jwt, char **alg);
 int oidc_proto_authorization_request(request_rec *r, struct oidc_provider_t *provider, const char *login_hint, const char *redirect_uri, const char *state, oidc_proto_state_t *proto_state, const char *id_token_hint, const char *code_challenge, const char *auth_request_params, const char *path_scope);

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -478,7 +478,7 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_CLIENT_ASSERTION_TYPE_JWT_BEARER "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 #define OIDC_PROTO_CLIENT_SECRET_BASIC "client_secret_basic"
-#define OIDC_PROTO_CLIENT_SECRET_BEARER   "client_secret_bearer"
+#define OIDC_PROTO_CLIENT_BEARER   "client_bearer"
 #define OIDC_PROTO_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_PROTO_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_PROTO_PRIVATE_KEY_JWT     "private_key_jwt"

--- a/src/mod_auth_openidc.h
+++ b/src/mod_auth_openidc.h
@@ -297,6 +297,7 @@ typedef struct oidc_oauth_t {
 	char *introspection_endpoint_method;
 	char *introspection_endpoint_params;
 	char *introspection_endpoint_auth;
+	char *introspection_client_auth_bearer_token;
 	char *introspection_token_param_name;
 	char *introspection_token_expiry_claim_name;
 	char *introspection_token_expiry_claim_format;
@@ -478,7 +479,6 @@ apr_byte_t oidc_oauth_get_bearer_token(request_rec *r, const char **access_token
 #define OIDC_PROTO_CLIENT_ASSERTION_TYPE_JWT_BEARER "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
 #define OIDC_PROTO_CLIENT_SECRET_BASIC "client_secret_basic"
-#define OIDC_PROTO_CLIENT_BEARER   "client_bearer"
 #define OIDC_PROTO_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_PROTO_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_PROTO_PRIVATE_KEY_JWT     "private_key_jwt"

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -65,6 +65,7 @@ static apr_byte_t oidc_oauth_validate_access_token(request_rec *r, oidc_cfg *c,
 		const char *token, char **response) {
 
 	char *basic_auth = NULL;
+    char *bearer_auth = NULL;
 
 	/* assemble parameters to call the token endpoint for validation */
 	apr_table_t *params = apr_table_make(r->pool, 4);
@@ -80,20 +81,20 @@ static apr_byte_t oidc_oauth_validate_access_token(request_rec *r, oidc_cfg *c,
 	if (oidc_proto_token_endpoint_auth(r, c,
 			c->oauth.introspection_endpoint_auth, c->oauth.client_id,
 			c->oauth.client_secret, c->oauth.introspection_endpoint_url, params,
-			&basic_auth) == FALSE)
+			&basic_auth, &bearer_auth) == FALSE)
 		return FALSE;
 
 	/* call the endpoint with the constructed parameter set and return the resulting response */
 	return apr_strnatcmp(c->oauth.introspection_endpoint_method,
 			OIDC_INTROSPECTION_METHOD_GET) == 0 ?
 					oidc_util_http_get(r, c->oauth.introspection_endpoint_url, params,
-							basic_auth, NULL, c->oauth.ssl_validate_server, response,
+							basic_auth, bearer_auth, c->oauth.ssl_validate_server, response,
 							c->http_timeout_long, c->outgoing_proxy,
 							oidc_dir_cfg_pass_cookies(r),
 							oidc_util_get_full_path(r->pool, c->oauth.introspection_endpoint_tls_client_cert),
 							oidc_util_get_full_path(r->pool, c->oauth.introspection_endpoint_tls_client_key)) :
 							oidc_util_http_post_form(r, c->oauth.introspection_endpoint_url,
-									params, basic_auth, NULL, c->oauth.ssl_validate_server,
+									params, basic_auth, bearer_auth, c->oauth.ssl_validate_server,
 									response, c->http_timeout_long, c->outgoing_proxy,
 									oidc_dir_cfg_pass_cookies(r),
 									oidc_util_get_full_path(r->pool, c->oauth.introspection_endpoint_tls_client_cert),

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -63,9 +63,11 @@
  */
 static apr_byte_t oidc_oauth_validate_access_token(request_rec *r, oidc_cfg *c,
 		const char *token, char **response) {
+	
+	oidc_debug(r, "enter");
 
 	char *basic_auth = NULL;
-    char *bearer_auth = NULL;
+	char *bearer_auth = NULL;
 
 	/* assemble parameters to call the token endpoint for validation */
 	apr_table_t *params = apr_table_make(r->pool, 4);

--- a/src/parse.c
+++ b/src/parse.c
@@ -376,7 +376,6 @@ const char *oidc_parse_boolean(apr_pool_t *pool, const char *arg,
 
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC "client_secret_basic"
-#define OIDC_ENDPOINT_AUTH_CLIENT_BEARER   "client_bearer"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_ENDPOINT_AUTH_PRIVATE_KEY_JWT     "private_key_jwt"
 #define OIDC_ENDPOINT_AUTH_NONE                "none"
@@ -389,7 +388,6 @@ static const char *oidc_valid_endpoint_auth_method_impl(apr_pool_t *pool,
 	static char *options[] = {
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC,
-			OIDC_ENDPOINT_AUTH_CLIENT_BEARER,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT,
 			OIDC_ENDPOINT_AUTH_NONE,
 			NULL,

--- a/src/parse.c
+++ b/src/parse.c
@@ -376,6 +376,7 @@ const char *oidc_parse_boolean(apr_pool_t *pool, const char *arg,
 
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC "client_secret_basic"
+#define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BEARER   "client_secret_bearer"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_ENDPOINT_AUTH_PRIVATE_KEY_JWT     "private_key_jwt"
 #define OIDC_ENDPOINT_AUTH_NONE                "none"
@@ -388,6 +389,7 @@ static const char *oidc_valid_endpoint_auth_method_impl(apr_pool_t *pool,
 	static char *options[] = {
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC,
+            OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BEARER,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT,
 			OIDC_ENDPOINT_AUTH_NONE,
 			NULL,

--- a/src/parse.c
+++ b/src/parse.c
@@ -376,7 +376,7 @@ const char *oidc_parse_boolean(apr_pool_t *pool, const char *arg,
 
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST  "client_secret_post"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC "client_secret_basic"
-#define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BEARER   "client_secret_bearer"
+#define OIDC_ENDPOINT_AUTH_CLIENT_BEARER   "client_bearer"
 #define OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT   "client_secret_jwt"
 #define OIDC_ENDPOINT_AUTH_PRIVATE_KEY_JWT     "private_key_jwt"
 #define OIDC_ENDPOINT_AUTH_NONE                "none"
@@ -389,7 +389,7 @@ static const char *oidc_valid_endpoint_auth_method_impl(apr_pool_t *pool,
 	static char *options[] = {
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_POST,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BASIC,
-            OIDC_ENDPOINT_AUTH_CLIENT_SECRET_BEARER,
+			OIDC_ENDPOINT_AUTH_CLIENT_BEARER,
 			OIDC_ENDPOINT_AUTH_CLIENT_SECRET_JWT,
 			OIDC_ENDPOINT_AUTH_NONE,
 			NULL,

--- a/src/proto.c
+++ b/src/proto.c
@@ -1809,7 +1809,7 @@ static apr_byte_t oidc_proto_endpoint_auth_client_secret_jwt(request_rec *r,
 	return TRUE;
 }
 
-static apr_byte_t oidc_proto_endpoint_auth_client_secret_bearer(request_rec *r,
+static apr_byte_t oidc_proto_endpoint_auth_client_bearer(request_rec *r,
 		oidc_cfg *cfg, apr_table_t *params, char **bearer_auth_str) {
 
     const char *token = apr_table_get(params, cfg->oauth.introspection_token_param_name);
@@ -1887,8 +1887,8 @@ apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg,
 				basic_auth_str);
 
    	if (apr_strnatcmp(token_endpoint_auth,
-			OIDC_PROTO_CLIENT_SECRET_BEARER) == 0)
-		return oidc_proto_endpoint_auth_client_secret_bearer(r, cfg, params, bearer_auth_str);
+			OIDC_PROTO_CLIENT_BEARER) == 0)
+		return oidc_proto_endpoint_auth_client_bearer(r, cfg, params, bearer_auth_str);
 
 	if (apr_strnatcmp(token_endpoint_auth,
 			OIDC_PROTO_CLIENT_SECRET_POST) == 0)

--- a/src/proto.c
+++ b/src/proto.c
@@ -1809,6 +1809,15 @@ static apr_byte_t oidc_proto_endpoint_auth_client_secret_jwt(request_rec *r,
 	return TRUE;
 }
 
+static apr_byte_t oidc_proto_endpoint_auth_client_secret_bearer(request_rec *r,
+		oidc_cfg *cfg, apr_table_t *params, char **bearer_auth_str) {
+
+    const char *token = apr_table_get(params, cfg->oauth.introspection_token_param_name);
+    *bearer_auth_str = apr_psprintf(r->pool, "%s", token);
+    
+	return TRUE;
+}
+
 #define OIDC_PROTO_JWT_ASSERTION_ASYMMETRIC_ALG CJOSE_HDR_ALG_RS256
 
 static apr_byte_t oidc_proto_endpoint_auth_private_key_jwt(request_rec *r,
@@ -1845,7 +1854,7 @@ static apr_byte_t oidc_proto_endpoint_auth_private_key_jwt(request_rec *r,
 apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg,
 		const char *token_endpoint_auth, const char *client_id,
 		const char *client_secret, const char *audience, apr_table_t *params,
-		char **basic_auth_str) {
+		char **basic_auth_str, char **bearer_auth_str) {
 
 	oidc_debug(r, "token_endpoint_auth=%s", token_endpoint_auth);
 
@@ -1877,6 +1886,10 @@ apr_byte_t oidc_proto_token_endpoint_auth(request_rec *r, oidc_cfg *cfg,
 		return oidc_proto_endpoint_auth_basic(r, client_id, client_secret,
 				basic_auth_str);
 
+   	if (apr_strnatcmp(token_endpoint_auth,
+			OIDC_PROTO_CLIENT_SECRET_BEARER) == 0)
+		return oidc_proto_endpoint_auth_client_secret_bearer(r, cfg, params, bearer_auth_str);
+
 	if (apr_strnatcmp(token_endpoint_auth,
 			OIDC_PROTO_CLIENT_SECRET_POST) == 0)
 		return oidc_proto_endpoint_auth_post(r, client_id, client_secret,
@@ -1907,11 +1920,12 @@ static apr_byte_t oidc_proto_token_endpoint_request(request_rec *r,
 
 	char *response = NULL;
 	char *basic_auth = NULL;
+    char *bearer_auth = NULL;
 
 	/* add the token endpoint authentication credentials */
 	if (oidc_proto_token_endpoint_auth(r, cfg, provider->token_endpoint_auth,
 			provider->client_id, provider->client_secret,
-			provider->token_endpoint_url, params, &basic_auth) == FALSE)
+			provider->token_endpoint_url, params, &basic_auth, &bearer_auth) == FALSE)
 		return FALSE;
 
 	/* add any configured extra static parameters to the token endpoint */
@@ -1920,7 +1934,7 @@ static apr_byte_t oidc_proto_token_endpoint_request(request_rec *r,
 
 	/* send the refresh request to the token endpoint */
 	if (oidc_util_http_post_form(r, provider->token_endpoint_url, params,
-			basic_auth, NULL, provider->ssl_validate_server, &response,
+			basic_auth, bearer_auth, provider->ssl_validate_server, &response,
 			cfg->http_timeout_long, cfg->outgoing_proxy,
 			oidc_dir_cfg_pass_cookies(r),
 			oidc_util_get_full_path(r->pool,


### PR DESCRIPTION
I have made these changes to accomodate Gluu server (and perhaps others) as it does not seem to support any other authorization method for the introspection endpoint, except a bearer token sent via Authorization header.

It seemed the functionality for using a bearer token was already there, only not used.

It is a bit of a hack, to use the same token received from a client, instead one obtained by mod_auth_openidc itself, but that would mean the module would first call the /token endpoint authorizing with Basic or other method, and then call the /introspection endpoint to validate the incoming bearer token from an external client. And this is not yet implemented.
